### PR TITLE
Updating API's version in documentation for customers.mdx

### DIFF
--- a/website/docs/guides/customers.mdx
+++ b/website/docs/guides/customers.mdx
@@ -99,7 +99,7 @@ $customer = $facturapi->Customers->create([
 <TabItem value="curl" label="cURL">
 
 ```bash
-curl https://www.facturapi.io/v1/customers \
+curl https://www.facturapi.io/v2/customers \
   -H "Authorization: Bearer sk_test_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{


### PR DESCRIPTION
Documentation for creating new customers still displays v1. When using version 1 we get the following error message: "La versión 1 de Facturapi ya no está disponible a partir del 1 de abril de 2023. Por favor actualiza a la versión 2 de la API, que soporta la versión de CFDI 4.0."
Updated to display v2.