### PR TITLE
Fix/sample method class names

### DIFF
--- a/website/openapi_v2.en.yaml
+++ b/website/openapi_v2.en.yaml
@@ -6585,7 +6585,7 @@ paths:
           source: |
             var facturapi = new FacturapiClient("sk_test_API_KEY");
             
-            var customer = await facturapi.Tools.ValidateTaxIdAsync("BBA830831LJ2");
+            var customer = await facturapi.Tool.ValidateTaxIdAsync("BBA830831LJ2");
         - lang: PHP
           source: |
             $facturapi = new Facturapi( "sk_test_API_KEY" );
@@ -7201,6 +7201,21 @@ components:
           type: string
           title: Error description
           description: Indicates what went wrong and may include a suggestion on how to fix the error.
+    IssuingType:
+      type: string
+      description: Indicates whether the invoice was issued by your organization or received from a third party.
+      enum:
+        - issuing
+        - receiving
+    CancellationStatus:
+      type: string
+      description: Status of the invoice cancellation request.
+      enum:
+        - none
+        - accepted
+        - pending
+        - rejected
+        - expired
 
     # Common base objects
     SearchResult:

--- a/website/openapi_v2.yaml
+++ b/website/openapi_v2.yaml
@@ -6531,7 +6531,7 @@ paths:
           source: |
             var facturapi = new FacturapiClient("sk_test_API_KEY");
             
-            var customer = await facturapi.Tools.ValidateTaxIdAsync("BBA830831LJ2");
+            var customer = await facturapi.Tool.ValidateTaxIdAsync("BBA830831LJ2");
         - lang: PHP
           source: |
             $facturapi = new Facturapi( "sk_test_API_KEY" );
@@ -7147,6 +7147,21 @@ components:
           type: string
           title: Descripción del error
           description: Indica qué salió mal y puede incluir una sugerencia sobre cómo solucionar el error.
+    IssuingType:
+      type: string
+      description: Indica si la factura fue emitida por tu organización o recibida de un tercero.
+      enum:
+        - issuing
+        - receiving
+    CancellationStatus:
+      type: string
+      description: Estado de la solicitud de cancelación de la factura.
+      enum:
+        - none
+        - accepted
+        - pending
+        - rejected
+        - expired
 
     # Common base objects
     SearchResult:


### PR DESCRIPTION
This pull request updates the OpenAPI documentation files (`website/openapi_v2.yaml` and `website/openapi_v2.en.yaml`) to improve accuracy and add new schema definitions. The most significant changes include correcting C# and JavaScript code samples for consistency with the API client, and introducing new schema components for invoice issuing type and cancellation status.

**Code sample corrections:**

* Updated all C# code samples to use the correct singular form (`Webhook`/`Tool`) instead of the plural (`Webhooks`/`Tools`) for API client method calls, ensuring consistency and accuracy in the documentation. [[1]](diffhunk://#diff-2e2b88cdfc33ca42a9bb0beb581f24f3ddf3af4e64134193f286bdd83fb4c43aL6208-R6208) [[2]](diffhunk://#diff-2e2b88cdfc33ca42a9bb0beb581f24f3ddf3af4e64134193f286bdd83fb4c43aL6260-R6265) [[3]](diffhunk://#diff-2e2b88cdfc33ca42a9bb0beb581f24f3ddf3af4e64134193f286bdd83fb4c43aL6328-R6328) [[4]](diffhunk://#diff-2e2b88cdfc33ca42a9bb0beb581f24f3ddf3af4e64134193f286bdd83fb4c43aL6393-R6393) [[5]](diffhunk://#diff-2e2b88cdfc33ca42a9bb0beb581f24f3ddf3af4e64134193f286bdd83fb4c43aL6588-R6588) [[6]](diffhunk://#diff-56da40a8df0de2c0cf1d5a63528f775c020086274aed0163d5b753cce49db7edL6159-R6159) [[7]](diffhunk://#diff-56da40a8df0de2c0cf1d5a63528f775c020086274aed0163d5b753cce49db7edL6210-R6215) [[8]](diffhunk://#diff-56da40a8df0de2c0cf1d5a63528f775c020086274aed0163d5b753cce49db7edL6277-R6277) [[9]](diffhunk://#diff-56da40a8df0de2c0cf1d5a63528f775c020086274aed0163d5b753cce49db7edL6341-R6341) [[10]](diffhunk://#diff-56da40a8df0de2c0cf1d5a63528f775c020086274aed0163d5b753cce49db7edL6534-R6534)
* Fixed the JavaScript code sample to use the correct lowercase property `webhooks` instead of `Webhooks`. [[1]](diffhunk://#diff-2e2b88cdfc33ca42a9bb0beb581f24f3ddf3af4e64134193f286bdd83fb4c43aL6260-R6265) [[2]](diffhunk://#diff-56da40a8df0de2c0cf1d5a63528f775c020086274aed0163d5b753cce49db7edL6210-R6215)

**Schema enhancements:**

* Added new schema components: `IssuingType` (to indicate if an invoice is issued or received) and `CancellationStatus` (to represent the status of an invoice cancellation request), with appropriate descriptions and enumerated values, in both English and Spanish documentation files. [[1]](diffhunk://#diff-2e2b88cdfc33ca42a9bb0beb581f24f3ddf3af4e64134193f286bdd83fb4c43aR7204-R7218) [[2]](diffhunk://#diff-56da40a8df0de2c0cf1d5a63528f775c020086274aed0163d5b753cce49db7edR7150-R7164)