### PR TITLE
[codex] Document live key organization config

### DIFF
--- a/website/docs/getting-started/concepts.md
+++ b/website/docs/getting-started/concepts.md
@@ -27,13 +27,15 @@ La API de Facturapi te permite crear, consultar y administrar los siguientes rec
 Existen 2 roles distintos con los que puedes identificarte en la API:
 
 - **Organización**. Identificarte como **organización** te permite emitir facturas usando la
-  información fiscal previamente configurada para la organización, así como crear, consultar y
-  realizar operaciones sobre recursos que le pertenezcan. Para identificarte con este rol,
-  deberás utilizar la **Test Secret Key** o la **Live Secret Key** de la organización,
-  dependiendo del **ambiente** que quieras utilizar.
-- **Usuario**. Identificarte como usuario te permite crear y administrar
-  organizaciones que pertenecerán a tu cuenta de usuario. Para identificarte con este
-  rol, deberás utilizar la **User Secret Key** de tu cuenta.
+  información fiscal configurada para la organización, así como crear, consultar y
+  realizar operaciones sobre recursos que le pertenezcan. La **Live Secret Key** también puede
+  modificar la configuración operativa de su propia organización, como datos fiscales,
+  certificados, logotipo, autofactura y series. Para identificarte con este rol, deberás
+  utilizar la **Test Secret Key** o la **Live Secret Key** de la organización, dependiendo del
+  **ambiente** que quieras utilizar.
+- **Usuario**. Identificarte como usuario te permite crear organizaciones, administrar
+  usuarios, roles, invitaciones y llaves API, y modificar organizaciones a las que tengas
+  acceso. Para identificarte con este rol, deberás utilizar la **User Secret Key** de tu cuenta.
 
 ## Ambientes
 
@@ -61,9 +63,9 @@ Sirven para identificar a una organización o a una cuenta de usuario al llamar 
 
 Existen 3 tipos de llaves secretas, cada una con una función específica:
 
-- **Test Secret Key**: Identifica a la organización en ambiente Test para crear y administrar recursos (clientes, facturas, etc.). Es única por organización.
-- **Live Secret Key**: Identifica a una Organización en ambiente Live para crear y administrar recursos (clientes, facturas, etc.). Es única por organización.
-- **User Secret Key**: Identifica a tu cuenta para crear y configurar organizaciones. Es única por cuenta.
+- **Test Secret Key**: Identifica a la organización en ambiente Test para crear y administrar recursos (clientes, facturas, etc.). También puede consultar la información de su propia organización, pero no modificar su configuración. Es única por organización.
+- **Live Secret Key**: Identifica a una organización en ambiente Live para crear y administrar recursos (clientes, facturas, etc.) y para configurar su propia organización. Es única por organización.
+- **User Secret Key**: Identifica a tu cuenta para crear organizaciones y administrar permisos, usuarios y llaves API. Es única por cuenta.
 
 Las llaves secretas se utilizan durante el proceso de [autenticación](/docs/getting-started/authenticate).
 

--- a/website/docs/getting-started/organization-onboarding.mdx
+++ b/website/docs/getting-started/organization-onboarding.mdx
@@ -6,6 +6,14 @@ sidebar_position: 1
 
 Esta guía resume el checklist de configuración en dashboard para dejar tu organización lista para emitir CFDI.
 
+También puedes automatizar la configuración operativa por API. Después de crear la organización,
+puedes usar tu **User Secret Key** o la **Live Secret Key** de esa organización para actualizar
+sus datos fiscales, CSD, logotipo, configuración de autofactura, recibos y series. La e.firma
+(FIEL) solo es necesaria para la descarga masiva de CFDI; para crear CFDI basta con cargar el
+CSD. La creación de organizaciones, la administración de usuarios y la administración de llaves
+API siguen requiriendo una **User Secret Key**. La suscripción se activa desde el dashboard o el
+flujo de billing correspondiente.
+
 ## Checklist de configuración inicial
 
 ### 1. Crear la organización

--- a/website/docs/guides/organizations.mdx
+++ b/website/docs/guides/organizations.mdx
@@ -21,9 +21,16 @@ Ese flujo puede resolverse desde API o directamente desde el dashboard, según
 qué tanto necesites automatizar la administración del equipo.
 
 :::info
-Recuerda que para crear y administrar organizaciones deberás autenticarte usando tu User Key,
-que es una llave secreta asociada a toda tu cuenta, la cual puedes encontrar en tu
-[Centro de Integración](https://dashboard.facturapi.io/integration).
+Para crear organizaciones, administrar usuarios, roles, invitaciones o llaves API deberás
+autenticarte usando tu User Key, que es una llave secreta asociada a toda tu cuenta y que
+puedes encontrar en tu [Centro de Integración](https://dashboard.facturapi.io/integration).
+
+Una vez creada una organización, también puedes configurar sus datos operativos con tu User Key
+o con la Live Secret Key (`sk_live_*`) de esa organización. Con la Live Secret Key puedes usar
+`me` como alias de la organización, o enviar explícitamente el ID de la organización, en endpoints
+como `/v2/organizations/me/legal`, `/v2/organizations/me/certificate`,
+`/v2/organizations/me/customization` y `/v2/organizations/me/series-group`. La Test Secret Key
+(`sk_test_*`) solo puede consultar la información de su propia organización.
 :::
 
 <Tabs groupId="codeExamples">

--- a/website/i18n/en/docusaurus-plugin-content-docs/current/getting-started/concepts.md
+++ b/website/i18n/en/docusaurus-plugin-content-docs/current/getting-started/concepts.md
@@ -26,8 +26,8 @@ The Facturapi API allows you to create, retrieve, and manage the following resou
 
 There are 2 different roles that you can identify yourself with in the API:
 
-- **Organization**: Identifying yourself as an organization allows you to issue invoices using the previously configured fiscal information for the organization, as well as create, retrieve, and perform operations on resources belonging to it. To identify yourself with this role, you must use the Test Secret Key or the Live Secret Key of the organization, depending on the environment you want to use.
-- **User**: Identifying yourself as a user allows you to create and manage organizations that belong to your user account. To identify yourself with this role, you must use the User Secret Key of your account.
+- **Organization**: Identifying yourself as an organization allows you to issue invoices using the configured fiscal information for the organization, as well as create, retrieve, and perform operations on resources belonging to it. The Live Secret Key can also update the operating configuration of its own organization, such as legal data, certificates, logo, self-invoice settings, receipts, and series. To identify yourself with this role, you must use the Test Secret Key or the Live Secret Key of the organization, depending on the environment you want to use.
+- **User**: Identifying yourself as a user allows you to create organizations, manage users, roles, invites, API keys, and update organizations you have access to. To identify yourself with this role, you must use the User Secret Key of your account.
 
 ## Environments
 
@@ -48,13 +48,12 @@ They are used to identify an organization or a user account when calling the Fac
 
 There are 3 types of secret keys, each with a specific function:
 
-- **Test Secret Key**: Identifies the organization in the Test environment to create and manage resources (clients, invoices, etc.). It is unique per organization.
-- **Live Secret Key**: Identifies an organization in the Live environment to create and manage resources (clients, invoices, etc.). It is unique per organization.
-- **User Secret Key**: Identifies your account to create and configure organizations. It is unique per account.
+- **Test Secret Key**: Identifies the organization in the Test environment to create and manage resources (clients, invoices, etc.). It can also read its own organization information, but it cannot update organization configuration. It is unique per organization.
+- **Live Secret Key**: Identifies an organization in the Live environment to create and manage resources (clients, invoices, etc.) and configure its own organization. It is unique per organization.
+- **User Secret Key**: Identifies your account to create organizations and manage permissions, users, and API keys. It is unique per account.
 
 The secret keys are used during the authentication process.
 
 To obtain your secret keys and create a free account on Facturapi, visit:
 
 [https://www.facturapi.io/register](https://www.facturapi.io/register?utm_source=facturapi-docs&utm_medium=GithubPages)
-

--- a/website/i18n/en/docusaurus-plugin-content-docs/current/getting-started/organization-onboarding.mdx
+++ b/website/i18n/en/docusaurus-plugin-content-docs/current/getting-started/organization-onboarding.mdx
@@ -6,6 +6,13 @@ sidebar_position: 1
 
 This guide summarizes the dashboard setup checklist to get your organization ready to issue CFDI.
 
+You can also automate the operating configuration through the API. After creating the organization,
+you can use your **User Secret Key** or that organization's **Live Secret Key** to update its legal
+data, CSD, logo, self-invoice settings, receipts, and series. The e.firma (FIEL) is only required
+for bulk CFDI downloads; to create CFDI you only need to upload the CSD. Organization creation,
+user management, and API key management still require a **User Secret Key**. The subscription is
+activated from the dashboard or the corresponding billing flow.
+
 ## Onboarding checklist
 
 ### 1. Create the organization

--- a/website/i18n/en/docusaurus-plugin-content-docs/current/guides/organizations.mdx
+++ b/website/i18n/en/docusaurus-plugin-content-docs/current/guides/organizations.mdx
@@ -22,9 +22,16 @@ That workflow can be handled either through the API or directly from the
 dashboard, depending on how much team administration you want to automate.
 
 :::info
-Remember that to create and manage organizations, you must authenticate using your User Key,
-which is a secret key associated with your entire account. You can find it in your
+To create organizations, manage users, roles, invites, or API keys, you must authenticate using
+your User Key, which is a secret key associated with your entire account. You can find it in your
 [Integration Center](https://dashboard.facturapi.io/integration).
+
+Once an organization exists, you can also configure its operating data with your User Key or with
+that organization's Live Secret Key (`sk_live_*`). With the Live Secret Key, you can use `me` as
+the organization alias, or send the organization ID explicitly, in endpoints such as
+`/v2/organizations/me/legal`, `/v2/organizations/me/certificate`,
+`/v2/organizations/me/customization`, and `/v2/organizations/me/series-group`. The Test Secret Key
+(`sk_test_*`) can only read its own organization information.
 :::
 
 <Tabs groupId="codeExamples">

--- a/website/openapi_v2.en.yaml
+++ b/website/openapi_v2.en.yaml
@@ -6894,7 +6894,6 @@ paths:
         $ref: "#/components/requestBodies/OrganizationEditLegal"
       security:
         - "SecretLiveKey": []
-        - "SecretTestKey": []
         - "SecretUserKey": []
       responses:
         "200":
@@ -7008,7 +7007,6 @@ paths:
         $ref: "#/components/requestBodies/OrganizationUploadCerts"
       security:
         - "SecretLiveKey": []
-        - "SecretTestKey": []
         - "SecretUserKey": []
       responses:
         "200":
@@ -7083,7 +7081,6 @@ paths:
           description: ID of the organization to delete certificates
       security:
         - "SecretLiveKey": []
-        - "SecretTestKey": []
         - "SecretUserKey": []
       responses:
         "200":
@@ -7092,6 +7089,58 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/OrganizationDeleteCerts"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthenticated"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "429":
+          $ref: "#/components/responses/RateLimited"
+        "500":
+          $ref: "#/components/responses/UnexpectedError"
+  /organizations/{organization_id}/fiel:
+    put:
+      operationId: uploadOrganizationFiel
+      tags:
+        - organization
+      summary: Upload FIEL certificate
+      description: |
+        Uploads the organization's e.firma (FIEL) files.
+
+        The e.firma (FIEL) is not required to create CFDI. To stamp CFDI, you
+        only need to upload the Digital Seal Certificate (CSD). The FIEL is
+        required to use bulk CFDI downloads.
+      x-codeSamples:
+        - lang: Bash
+          label: cURL
+          source: |
+            curl https://www.facturapi.io/v2/organizations/me/fiel \
+              -X PUT \
+              -H "Authorization: Bearer sk_live_API_KEY" \
+              -H "Content-Type: multipart/form-data" \
+              -F 'cer=@/path/to/your/FIEL.cer' \
+              -F 'key=@/path/to/your/FIEL.key' \
+              -F 'password=CERTIFICATE_PASSWORD'
+      parameters:
+        - in: path
+          name: organization_id
+          schema:
+            type: string
+          required: true
+          description: Organization ID. You can also use `me` with the organization's Live Secret Key.
+      requestBody:
+        $ref: "#/components/requestBodies/OrganizationUploadFiel"
+      security:
+        - "SecretLiveKey": []
+        - "SecretUserKey": []
+      responses:
+        "200":
+          description: Modified `Organization` object
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Organization"
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -7179,7 +7228,6 @@ paths:
         $ref: "#/components/requestBodies/OrganizationUploadLogo"
       security:
         - "SecretLiveKey": []
-        - "SecretTestKey": []
         - "SecretUserKey": []
       responses:
         "200":
@@ -7294,7 +7342,6 @@ paths:
         $ref: "#/components/requestBodies/OrganizationEditCustomization"
       security:
         - "SecretLiveKey": []
-        - "SecretTestKey": []
         - "SecretUserKey": []
       responses:
         "200":
@@ -7400,7 +7447,6 @@ paths:
         $ref: "#/components/requestBodies/OrganizationEditReceiptsSettings"
       security:
         - "SecretLiveKey": []
-        - "SecretTestKey": []
         - "SecretUserKey": []
       responses:
         "200":
@@ -7503,7 +7549,6 @@ paths:
         $ref: "#/components/requestBodies/OrganizationEditSelfInvoiceSettings"
       security:
         - "SecretLiveKey": []
-        - "SecretTestKey": []
         - "SecretUserKey": []
       responses:
         "200":
@@ -7582,8 +7627,6 @@ paths:
           schema:
             $ref: "#/components/schemas/DomainField"
       security:
-        - "SecretLiveKey": []
-        - "SecretTestKey": []
         - "SecretUserKey": []
       responses:
         "200":
@@ -7689,7 +7732,6 @@ paths:
         $ref: "#/components/requestBodies/OrganizationEditDomain"
       security:
         - "SecretLiveKey": []
-        - "SecretTestKey": []
         - "SecretUserKey": []
       responses:
         "200":
@@ -7836,8 +7878,6 @@ paths:
           required: true
           description: ID of the organization
       security:
-        - "SecretLiveKey": []
-        - "SecretTestKey": []
         - "SecretUserKey": []
       responses:
         "200":
@@ -7910,8 +7950,6 @@ paths:
           required: true
           description: ID of the organization
       security:
-        - "SecretLiveKey": []
-        - "SecretTestKey": []
         - "SecretUserKey": []
       responses:
         "200":
@@ -7985,8 +8023,6 @@ paths:
           required: true
           description: ID of the organization
       security:
-        - "SecretLiveKey": []
-        - "SecretTestKey": []
         - "SecretUserKey": []
       responses:
         "200":
@@ -8060,8 +8096,6 @@ paths:
           required: true
           description: Organization ID
       security:
-        - "SecretLiveKey": []
-        - "SecretTestKey": []
         - "SecretUserKey": []
       responses:
         "200":
@@ -8096,10 +8130,11 @@ paths:
       operationId: renewLiveApiKey
       tags:
         - organization
-      summary: Renew Live API Key
+      summary: Create Live API Key
       description: |
         Generate a new Live environment secret key for the organization.
-        This operation does not invalidate previously generated keys.
+        This operation does not invalidate previously generated keys. The endpoint uses `PUT`
+        for historical compatibility, but its behavior is to create a new key.
       x-codeSamples:
         - lang: Bash
           label: cURL
@@ -8149,8 +8184,6 @@ paths:
           required: true
           description: ID of the organization
       security:
-        - "SecretLiveKey": []
-        - "SecretTestKey": []
         - "SecretUserKey": []
       responses:
         "200":
@@ -8235,8 +8268,6 @@ paths:
           required: true
           description: ID of the Live API Key
       security:
-        - "SecretLiveKey": []
-        - "SecretTestKey": []
         - "SecretUserKey": []
       responses:
         "200":
@@ -8325,7 +8356,6 @@ paths:
           description: Organization ID
       security:
         - "SecretLiveKey": []
-        - "SecretTestKey": []
         - "SecretUserKey": []
       responses:
         "200":
@@ -8433,7 +8463,6 @@ paths:
           description: Organization ID
       security:
         - "SecretLiveKey": []
-        - "SecretTestKey": []
         - "SecretUserKey": []
       responses:
         "200":
@@ -8533,7 +8562,6 @@ paths:
           description: Organization ID
       security:
         - "SecretLiveKey": []
-        - "SecretTestKey": []
         - "SecretUserKey": []
       responses:
         "200":
@@ -8637,7 +8665,6 @@ paths:
           description: Series name
       security:
         - "SecretLiveKey": []
-        - "SecretTestKey": []
         - "SecretUserKey": []
       responses:
         "200":
@@ -8721,7 +8748,6 @@ paths:
           description: Series Name
       security:
         - "SecretLiveKey": []
-        - "SecretTestKey": []
         - "SecretUserKey": []
       responses:
         "200":
@@ -8787,8 +8813,6 @@ paths:
           required: true
           description: Organization ID
       security:
-        - "SecretLiveKey": []
-        - "SecretTestKey": []
         - "SecretUserKey": []
       responses:
         "200":
@@ -8883,8 +8907,6 @@ paths:
       requestBody:
         $ref: "#/components/requestBodies/OrganizationInviteCreate"
       security:
-        - "SecretLiveKey": []
-        - "SecretTestKey": []
         - "SecretUserKey": []
       responses:
         "200":
@@ -8951,8 +8973,6 @@ paths:
           required: true
           description: Organization ID
       security:
-        - "SecretLiveKey": []
-        - "SecretTestKey": []
         - "SecretUserKey": []
       responses:
         "200":
@@ -9025,8 +9045,6 @@ paths:
           required: true
           description: Access ID
       security:
-        - "SecretLiveKey": []
-        - "SecretTestKey": []
         - "SecretUserKey": []
       responses:
         "200":
@@ -9098,8 +9116,6 @@ paths:
           required: true
           description: Access ID
       security:
-        - "SecretLiveKey": []
-        - "SecretTestKey": []
         - "SecretUserKey": []
       responses:
         "200":
@@ -9175,8 +9191,6 @@ paths:
           required: true
           description: Public invite key
       security:
-        - "SecretLiveKey": []
-        - "SecretTestKey": []
         - "SecretUserKey": []
       responses:
         "200":
@@ -9384,8 +9398,6 @@ paths:
           required: true
           description: Organization ID
       security:
-        - "SecretLiveKey": []
-        - "SecretTestKey": []
         - "SecretUserKey": []
       responses:
         "200":
@@ -9467,8 +9479,6 @@ paths:
       requestBody:
         $ref: "#/components/requestBodies/OrganizationPermissionRoleCreate"
       security:
-        - "SecretLiveKey": []
-        - "SecretTestKey": []
         - "SecretUserKey": []
       responses:
         "200":
@@ -9535,8 +9545,6 @@ paths:
           required: true
           description: Organization ID
       security:
-        - "SecretLiveKey": []
-        - "SecretTestKey": []
         - "SecretUserKey": []
       responses:
         "200":
@@ -9601,8 +9609,6 @@ paths:
           required: true
           description: Organization ID
       security:
-        - "SecretLiveKey": []
-        - "SecretTestKey": []
         - "SecretUserKey": []
       responses:
         "200":
@@ -9674,8 +9680,6 @@ paths:
           required: true
           description: Role ID
       security:
-        - "SecretLiveKey": []
-        - "SecretTestKey": []
         - "SecretUserKey": []
       responses:
         "200":
@@ -9764,8 +9768,6 @@ paths:
       requestBody:
         $ref: "#/components/requestBodies/OrganizationPermissionRoleUpdate"
       security:
-        - "SecretLiveKey": []
-        - "SecretTestKey": []
         - "SecretUserKey": []
       responses:
         "200":
@@ -9839,8 +9841,6 @@ paths:
           required: true
           description: Role ID
       security:
-        - "SecretLiveKey": []
-        - "SecretTestKey": []
         - "SecretUserKey": []
       responses:
         "200":
@@ -9924,8 +9924,6 @@ paths:
       requestBody:
         $ref: "#/components/requestBodies/OrganizationUserAccessRoleUpdate"
       security:
-        - "SecretLiveKey": []
-        - "SecretTestKey": []
         - "SecretUserKey": []
       responses:
         "200":
@@ -11088,6 +11086,12 @@ components:
         multipart/form-data:
           schema:
             $ref: "#/components/schemas/OrganizationCertsInput"
+    OrganizationUploadFiel:
+      required: true
+      content:
+        multipart/form-data:
+          schema:
+            $ref: "#/components/schemas/OrganizationFielInput"
     OrganizationUploadLogo:
       required: true
       content:
@@ -16625,7 +16629,7 @@ components:
         fiel:
           type: object
           description: |
-            Useful information about the organization's FIEL certificate, which will be used to activate the Descarga Masiva service.
+            Useful information about the organization's FIEL certificate, which is used for the bulk CFDI download service.
           properties:
             has_certificate:
               type: boolean
@@ -16777,6 +16781,24 @@ components:
         password:
           type: string
           description: Password of the certificate key.
+    OrganizationFielInput:
+      type: object
+      required:
+        - cer
+        - key
+        - password
+      properties:
+        cer:
+          type: string
+          format: binary
+          description: Binary content of the e.firma (FIEL) file with extension `.cer`.
+        key:
+          type: string
+          format: binary
+          description: Binary content of the e.firma (FIEL) file with extension `.key`.
+        password:
+          type: string
+          description: Password for the e.firma (FIEL) private key.
     OrganizationLogoInput:
       type: object
       required:

--- a/website/openapi_v2.yaml
+++ b/website/openapi_v2.yaml
@@ -7110,7 +7110,6 @@ paths:
         $ref: "#/components/requestBodies/OrganizationEditLegal"
       security:
         - "SecretLiveKey": []
-        - "SecretTestKey": []
         - "SecretUserKey": []
       responses:
         "200":
@@ -7222,7 +7221,6 @@ paths:
         $ref: "#/components/requestBodies/OrganizationUploadCerts"
       security:
         - "SecretLiveKey": []
-        - "SecretTestKey": []
         - "SecretUserKey": []
       responses:
         "200":
@@ -7297,7 +7295,6 @@ paths:
           description: ID de la organización
       security:
         - "SecretLiveKey": []
-        - "SecretTestKey": []
         - "SecretUserKey": []
       responses:
         "200":
@@ -7306,6 +7303,58 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/OrganizationDeleteCerts"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthenticated"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "429":
+          $ref: "#/components/responses/RateLimited"
+        "500":
+          $ref: "#/components/responses/UnexpectedError"
+  /organizations/{organization_id}/fiel:
+    put:
+      operationId: uploadOrganizationFiel
+      tags:
+        - organization
+      summary: Subir certificado FIEL
+      description: |
+        Sube los archivos de la e.firma (FIEL) de la organización.
+
+        La e.firma (FIEL) no es necesaria para crear CFDI. Para timbrar CFDI
+        solo necesitas cargar el Certificado de Sello Digital (CSD). La FIEL es
+        necesaria para utilizar la descarga masiva de CFDI.
+      x-codeSamples:
+        - lang: Bash
+          label: cURL
+          source: |
+            curl https://www.facturapi.io/v2/organizations/me/fiel \
+              -X PUT \
+              -H "Authorization: Bearer sk_live_API_KEY" \
+              -H "Content-Type: multipart/form-data" \
+              -F 'cer=@/path/to/your/FIEL.cer' \
+              -F 'key=@/path/to/your/FIEL.key' \
+              -F 'password=CONTRASEÑA_DEL_CERTIFICADO'
+      parameters:
+        - in: path
+          name: organization_id
+          schema:
+            type: string
+          required: true
+          description: ID de la organización. También puedes usar `me` con la Live Secret Key de la organización.
+      requestBody:
+        $ref: "#/components/requestBodies/OrganizationUploadFiel"
+      security:
+        - "SecretLiveKey": []
+        - "SecretUserKey": []
+      responses:
+        "200":
+          description: Objeto `Organization` modificado
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Organization"
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -7396,7 +7445,6 @@ paths:
         $ref: "#/components/requestBodies/OrganizationUploadLogo"
       security:
         - "SecretLiveKey": []
-        - "SecretTestKey": []
         - "SecretUserKey": []
       responses:
         "200":
@@ -7511,7 +7559,6 @@ paths:
         $ref: "#/components/requestBodies/OrganizationEditCustomization"
       security:
         - "SecretLiveKey": []
-        - "SecretTestKey": []
         - "SecretUserKey": []
       responses:
         "200":
@@ -7617,7 +7664,6 @@ paths:
         $ref: "#/components/requestBodies/OrganizationEditReceiptsSettings"
       security:
         - "SecretLiveKey": []
-        - "SecretTestKey": []
         - "SecretUserKey": []
       responses:
         "200":
@@ -7720,7 +7766,6 @@ paths:
         $ref: "#/components/requestBodies/OrganizationEditSelfInvoiceSettings"
       security:
         - "SecretLiveKey": []
-        - "SecretTestKey": []
         - "SecretUserKey": []
       responses:
         "200":
@@ -7798,8 +7843,6 @@ paths:
           schema:
             $ref: "#/components/schemas/DomainField"
       security:
-        - "SecretLiveKey": []
-        - "SecretTestKey": []
         - "SecretUserKey": []
       responses:
         "200":
@@ -7905,7 +7948,6 @@ paths:
         $ref: "#/components/requestBodies/OrganizationEditDomain"
       security:
         - "SecretLiveKey": []
-        - "SecretTestKey": []
         - "SecretUserKey": []
       responses:
         "200":
@@ -8051,8 +8093,6 @@ paths:
           required: true
           description: ID del objeto a eliminar
       security:
-        - "SecretLiveKey": []
-        - "SecretTestKey": []
         - "SecretUserKey": []
       responses:
         "200":
@@ -8124,8 +8164,6 @@ paths:
           required: true
           description: ID de la organización
       security:
-        - "SecretLiveKey": []
-        - "SecretTestKey": []
         - "SecretUserKey": []
       responses:
         "200":
@@ -8148,7 +8186,8 @@ paths:
       tags:
         - organization
       summary: Renovar Test API Key
-      description: Renueva la llave secreta de ambiente Test de la organización e invalida inmediatamente la anterior.
+      description: |
+        Renueva la llave secreta de ambiente Test de la organización e invalida inmediatamente la anterior.
       x-codeSamples:
         - lang: Bash
           label: cURL
@@ -8198,8 +8237,6 @@ paths:
           required: true
           description: ID de la organización
       security:
-        - "SecretLiveKey": []
-        - "SecretTestKey": []
         - "SecretUserKey": []
       responses:
         "200":
@@ -8273,8 +8310,6 @@ paths:
           required: true
           description: ID de la organización
       security:
-        - "SecretLiveKey": []
-        - "SecretTestKey": []
         - "SecretUserKey": []
       responses:
         "200":
@@ -8308,10 +8343,11 @@ paths:
       operationId: renewLiveApiKey
       tags:
         - organization
-      summary: Renovar Live API Key
+      summary: Crear Live API Key
       description: |
         Genera una nueva llave secreta de ambiente Live de la organización.
-        Esta operación no invalida las llaves generadas previamente.
+        Esta operación no invalida las llaves generadas previamente. El endpoint usa `PUT`
+        por compatibilidad histórica, pero su comportamiento es crear una nueva llave.
       x-codeSamples:
         - lang: Bash
           label: cURL
@@ -8361,8 +8397,6 @@ paths:
           required: true
           description: ID de la organización
       security:
-        - "SecretLiveKey": []
-        - "SecretTestKey": []
         - "SecretUserKey": []
       responses:
         "200":
@@ -8447,8 +8481,6 @@ paths:
           required: true
           description: ID de la llave secreta a eliminar
       security:
-        - "SecretLiveKey": []
-        - "SecretTestKey": []
         - "SecretUserKey": []
       responses:
         "200":
@@ -8537,7 +8569,6 @@ paths:
           description: ID de la organización
       security:
         - "SecretLiveKey": []
-        - "SecretTestKey": []
         - "SecretUserKey": []
       responses:
         "200":
@@ -8645,7 +8676,6 @@ paths:
           description: ID de la organización
       security:
         - "SecretLiveKey": []
-        - "SecretTestKey": []
         - "SecretUserKey": []
       responses:
         "200":
@@ -8745,7 +8775,6 @@ paths:
           description: ID de la organización
       security:
         - "SecretLiveKey": []
-        - "SecretTestKey": []
         - "SecretUserKey": []
       responses:
         "200":
@@ -8849,7 +8878,6 @@ paths:
           description: Nombre de la serie
       security:
         - "SecretLiveKey": []
-        - "SecretTestKey": []
         - "SecretUserKey": []
       responses:
         "200":
@@ -8933,7 +8961,6 @@ paths:
           description: Nombre de la serie
       security:
         - "SecretLiveKey": []
-        - "SecretTestKey": []
         - "SecretUserKey": []
       responses:
         "200":
@@ -8999,8 +9026,6 @@ paths:
           required: true
           description: ID de la organización
       security:
-        - "SecretLiveKey": []
-        - "SecretTestKey": []
         - "SecretUserKey": []
       responses:
         "200":
@@ -9095,8 +9120,6 @@ paths:
       requestBody:
         $ref: "#/components/requestBodies/OrganizationInviteCreate"
       security:
-        - "SecretLiveKey": []
-        - "SecretTestKey": []
         - "SecretUserKey": []
       responses:
         "200":
@@ -9163,8 +9186,6 @@ paths:
           required: true
           description: ID de la organización
       security:
-        - "SecretLiveKey": []
-        - "SecretTestKey": []
         - "SecretUserKey": []
       responses:
         "200":
@@ -9237,8 +9258,6 @@ paths:
           required: true
           description: ID del acceso
       security:
-        - "SecretLiveKey": []
-        - "SecretTestKey": []
         - "SecretUserKey": []
       responses:
         "200":
@@ -9310,8 +9329,6 @@ paths:
           required: true
           description: ID del acceso
       security:
-        - "SecretLiveKey": []
-        - "SecretTestKey": []
         - "SecretUserKey": []
       responses:
         "200":
@@ -9387,8 +9404,6 @@ paths:
           required: true
           description: Clave pública de la invitación.
       security:
-        - "SecretLiveKey": []
-        - "SecretTestKey": []
         - "SecretUserKey": []
       responses:
         "200":
@@ -9596,8 +9611,6 @@ paths:
           required: true
           description: ID de la organización
       security:
-        - "SecretLiveKey": []
-        - "SecretTestKey": []
         - "SecretUserKey": []
       responses:
         "200":
@@ -9679,8 +9692,6 @@ paths:
       requestBody:
         $ref: "#/components/requestBodies/OrganizationPermissionRoleCreate"
       security:
-        - "SecretLiveKey": []
-        - "SecretTestKey": []
         - "SecretUserKey": []
       responses:
         "200":
@@ -9747,8 +9758,6 @@ paths:
           required: true
           description: ID de la organización
       security:
-        - "SecretLiveKey": []
-        - "SecretTestKey": []
         - "SecretUserKey": []
       responses:
         "200":
@@ -9813,8 +9822,6 @@ paths:
           required: true
           description: ID de la organización
       security:
-        - "SecretLiveKey": []
-        - "SecretTestKey": []
         - "SecretUserKey": []
       responses:
         "200":
@@ -9886,8 +9893,6 @@ paths:
           required: true
           description: ID del rol
       security:
-        - "SecretLiveKey": []
-        - "SecretTestKey": []
         - "SecretUserKey": []
       responses:
         "200":
@@ -9976,8 +9981,6 @@ paths:
       requestBody:
         $ref: "#/components/requestBodies/OrganizationPermissionRoleUpdate"
       security:
-        - "SecretLiveKey": []
-        - "SecretTestKey": []
         - "SecretUserKey": []
       responses:
         "200":
@@ -10051,8 +10054,6 @@ paths:
           required: true
           description: ID del rol
       security:
-        - "SecretLiveKey": []
-        - "SecretTestKey": []
         - "SecretUserKey": []
       responses:
         "200":
@@ -10136,8 +10137,6 @@ paths:
       requestBody:
         $ref: "#/components/requestBodies/OrganizationUserAccessRoleUpdate"
       security:
-        - "SecretLiveKey": []
-        - "SecretTestKey": []
         - "SecretUserKey": []
       responses:
         "200":
@@ -11291,6 +11290,12 @@ components:
         multipart/form-data:
           schema:
             $ref: "#/components/schemas/OrganizationCertsInput"
+    OrganizationUploadFiel:
+      required: true
+      content:
+        multipart/form-data:
+          schema:
+            $ref: "#/components/schemas/OrganizationFielInput"
     OrganizationUploadLogo:
       required: true
       content:
@@ -16852,7 +16857,7 @@ components:
               description: Número de serie del certificado CSD.
         fiel:
           type: object
-          description: Información sobre el certificado FIEL de la organización, que se utiliza para el servicio de Descarga Masiva.
+          description: Información sobre el certificado FIEL de la organización, que se utiliza para el servicio de descarga masiva de CFDI.
           properties:
             has_certificate:
               type: boolean
@@ -17009,6 +17014,24 @@ components:
         password:
           type: string
           description: Contraseña de la llave del certificado.
+    OrganizationFielInput:
+      type: object
+      required:
+        - cer
+        - key
+        - password
+      properties:
+        cer:
+          type: string
+          format: binary
+          description: Contenido binario del archivo con extensión `.cer` de la e.firma (FIEL).
+        key:
+          type: string
+          format: binary
+          description: Contenido binario del archivo con extensión `.key` de la e.firma (FIEL).
+        password:
+          type: string
+          description: Contraseña de la llave privada de la e.firma (FIEL).
     OrganizationLogoInput:
       type: object
       required:


### PR DESCRIPTION
## Resumen

- Documenta que una organización existente puede configurar sus datos operativos con su propia Live Secret Key (`sk_live_*`) o con User Secret Key.
- Aclara que la Test Secret Key (`sk_test_*`) solo puede consultar la información de su propia organización y no modificar configuración.
- Mantiene la User Secret Key como requisito para crear organizaciones, administrar usuarios/roles/invitaciones y administrar API keys.
- Aclara que la suscripción se activa desde dashboard o el flujo de billing correspondiente.
- Actualiza OpenAPI v2 en español e inglés para reflejar las credenciales permitidas por endpoint.
- Agrega documentación OpenAPI para subir FIEL por API y aclara que FIEL es para descarga masiva de CFDI, no para crear CFDI.

## Relacionado

- Depende del cambio de core: https://github.com/FacturAPI/facturapi/pull/1954

## Validación

- `ruby -e 'require "yaml"; YAML.load_file("website/openapi_v2.yaml"); YAML.load_file("website/openapi_v2.en.yaml")'`
- `yarn --cwd website typecheck`
- `yarn --cwd website build`
- `git diff --check`
