### PR TITLE
[codex] Document error codes as strings

### DIFF
--- a/website/openapi_v2.en.yaml
+++ b/website/openapi_v2.en.yaml
@@ -11265,9 +11265,7 @@ components:
           example: false
         code:
           description: Optional error code (for example, RATE_LIMIT_EXCEEDED).
-          oneOf:
-            - type: string
-            - type: integer
+          type: string
         path:
           type: string
           description: Optional path to the field related to the error.

--- a/website/openapi_v2.yaml
+++ b/website/openapi_v2.yaml
@@ -11498,9 +11498,7 @@ components:
           example: false
         code:
           description: Código de error opcional (por ejemplo, RATE_LIMIT_EXCEEDED).
-          oneOf:
-            - type: string
-            - type: integer
+          type: string
         path:
           type: string
           description: Ruta opcional del campo relacionado con el error.


### PR DESCRIPTION
## What changed

- Updated the v2 OpenAPI error schema in Spanish and English so `code` is documented as `string` only.

## Why

The API is normalizing public error codes to string identifiers, so the documentation should no longer advertise integer error codes.

## Validation

- Parsed `website/openapi_v2.yaml` and `website/openapi_v2.en.yaml` with `js-yaml`.

Note: PyYAML still fails on an existing timestamp issue in the spec, unrelated to this change.
