### PR TITLE
Clarify description for canceled_at field in openapi_v2.yaml

### DIFF
--- a/website/openapi_v2.yaml
+++ b/website/openapi_v2.yaml
@@ -14664,7 +14664,7 @@ components:
         canceled_at:
           type: string
           format: date-time
-          description: Fecha cercana a la hora donde se canceló CFDI
+          description: Fecha en la que se canceló el CFDI con hora aproximada. 
         verification_url:
           type: string
           format: uri


### PR DESCRIPTION
Updated the description for the canceled_at field to provide clearer information.