### PR TITLE
Document receipt invoicing customer rules

### DIFF
--- a/website/docs/guides/receipts.mdx
+++ b/website/docs/guides/receipts.mdx
@@ -144,7 +144,7 @@ curl https://www.facturapi.io/v2/receipts \
 
 ## Asignar un cliente a un recibo existente
 
-Puedes asignar un cliente a un recibo existente con el método
+Puedes asignar o reasignar un cliente a un recibo existente con el método
 [Asignar cliente a recibo](/api/#tag/receipt/operation/assignReceiptCustomer).
 
 ```bash

--- a/website/docs/guides/receipts.mdx
+++ b/website/docs/guides/receipts.mdx
@@ -149,9 +149,6 @@ Puedes asociar un cliente al recibo desde el método
 [Asignar o reasignar cliente a recibo](/api/#tag/receipt/operation/assignReceiptCustomer).
 En ambos casos puedes enviar el ID de un cliente existente o un objeto para crear uno nuevo.
 
-Al reasignar un cliente, Facturapi también actualiza la transacción asociada al recibo,
-si existe.
-
 ```bash
 curl https://www.facturapi.io/v2/receipts/58e93bd8e86eb318b019743d \
   -H "Authorization: Bearer sk_test_API_KEY" \

--- a/website/docs/guides/receipts.mdx
+++ b/website/docs/guides/receipts.mdx
@@ -141,8 +141,7 @@ curl https://www.facturapi.io/v2/receipts \
 ## Cliente asociado al recibo
 
 Un recibo puede existir sin cliente asociado. Ese estado significa que el destino de
-facturación todavía no está decidido: el recibo puede terminar en una autofactura, en
-una factura a un cliente específico o en una factura global.
+facturación todavía no está decidido.
 
 Puedes asociar un cliente al recibo desde el método
 [Crear Recibo](/api/#tag/receipt/operation/createReceipt), enviando el campo
@@ -163,23 +162,6 @@ curl https://www.facturapi.io/v2/receipts/58e93bd8e86eb318b019743d \
   }'
 ```
 
-Estas son las reglas al facturar recibos:
-
-- [Facturar un recibo](/api/#tag/receipt/operation/invoiceReceipt): si envías
-  `customer`, ese cliente se usa como receptor de la factura y sobrescribe el cliente
-  asignado previamente al recibo. Si omites `customer`, el recibo debe tener un cliente
-  asignado.
-- [Facturar múltiples recibos](/api/#tag/receipt/operation/createToInvoiceFromReceipts):
-  si envías `customer`, ese cliente se usa para todos los recibos incluidos. Si omites
-  `customer`, todos los recibos deben tener asignado el mismo cliente; si hay clientes
-  distintos o recibos sin cliente, la operación falla.
-- [Vista previa PDF de factura múltiple](/api/#tag/receipt/operation/previewToInvoiceFromReceipts)
-  y `dry_run` validan las mismas reglas de cliente que la creación real, pero no
-  persisten cambios.
-- [Factura global](/api/#tag/receipt/operation/createGlobalInvoice): Facturapi usa el
-  cliente genérico `PUBLICO EN GENERAL` como receptor y actualiza los recibos incluidos
-  con ese cliente.
-
 ## Portal de Autofactura
 
 Cuando creas un e-receipt, tienes la opción de enviarlo por correo electrónico a tu cliente.
@@ -188,11 +170,33 @@ llenar sus datos fiscales y descargar su factura.
 
 Para más información consulta el artículo de [Autofactura](/docs/guides/self-invoice).
 
+## Formas de facturar recibos
+
+Los recibos abiertos pueden facturarse a un cliente específico o incluirse en una
+factura global a `PUBLICO EN GENERAL`.
+
+- [Facturar un recibo](/api/#tag/receipt/operation/invoiceReceipt) crea una factura
+  para un solo recibo. Si envías `customer`, ese cliente se usa como receptor y
+  sobrescribe el cliente asignado previamente al recibo. Si omites `customer`, el
+  recibo debe tener un cliente asignado.
+- [Facturar múltiples recibos](/api/#tag/receipt/operation/createToInvoiceFromReceipts)
+  crea una factura para varios recibos seleccionados por `key`. Si envías `customer`,
+  ese cliente se usa para todos los recibos incluidos. Si omites `customer`, todos los
+  recibos deben tener asignado el mismo cliente; si hay clientes distintos o recibos
+  sin cliente, la operación falla.
+- [Vista previa PDF de factura múltiple](/api/#tag/receipt/operation/previewToInvoiceFromReceipts)
+  y `dry_run` validan las mismas reglas de cliente que la creación real, pero no
+  persisten cambios.
+- [Factura global](/api/#tag/receipt/operation/createGlobalInvoice) también agrupa
+  múltiples recibos, pero siempre los factura al cliente genérico `PUBLICO EN GENERAL`.
+  Los recibos incluidos quedan asociados a ese cliente y cambian su `status` a
+  `"invoiced_globally"`.
+
 ## Facturar un recibo
 
 Por medio del método [Facturar Recibo](/api/#tag/receipt/operation/invoiceReceipt) puedes convertir
-un e-receipt en una factura. Consulta las reglas de `customer` en la sección
-[Cliente asociado al recibo](#cliente-asociado-al-recibo).
+un e-receipt en una factura. Consulta las reglas completas en la sección
+[Formas de facturar recibos](#formas-de-facturar-recibos).
 
 <Tabs groupId="codeExamples">
 <TabItem value="js" label="Node.js" default>
@@ -267,5 +271,5 @@ curl https://www.facturapi.io/v2/receipts/5ebd8e56f5687a013ca0df46/invoice \
 El método [Facturar múltiples recibos](/api/#tag/receipt/operation/createToInvoiceFromReceipts)
 crea una sola factura a partir de recibos abiertos seleccionados por `key`.
 
-Consulta las reglas de `customer`, `dry_run` y vista previa PDF en la sección
-[Cliente asociado al recibo](#cliente-asociado-al-recibo).
+Consulta las reglas completas en la sección
+[Formas de facturar recibos](#formas-de-facturar-recibos).

--- a/website/docs/guides/receipts.mdx
+++ b/website/docs/guides/receipts.mdx
@@ -189,7 +189,7 @@ factura global a `PUBLICO EN GENERAL`.
   Los recibos incluidos quedan asociados a ese cliente y cambian su `status` a
   `"invoiced_globally"`.
 
-## Facturar un recibo
+### Facturar un recibo
 
 Por medio del método [Facturar Recibo](/api/#tag/receipt/operation/invoiceReceipt) puedes convertir
 un e-receipt en una factura. Consulta las reglas completas en la sección
@@ -263,7 +263,7 @@ curl https://www.facturapi.io/v2/receipts/5ebd8e56f5687a013ca0df46/invoice \
 </TabItem>
 </Tabs>
 
-## Facturar múltiples recibos
+### Facturar múltiples recibos
 
 El método [Facturar múltiples recibos](/api/#tag/receipt/operation/createToInvoiceFromReceipts)
 crea una sola factura a partir de recibos abiertos seleccionados por `key`.

--- a/website/docs/guides/receipts.mdx
+++ b/website/docs/guides/receipts.mdx
@@ -164,8 +164,12 @@ Para más información consulta el artículo de [Autofactura](/docs/guides/self-
 ## Facturar un recibo
 
 Por medio del método [Facturar Recibo](/api/#tag/receipt/operation/invoiceReceipt) puedes convertir
-un e-receipt en una factura. Para ello, debes enviar los datos del cliente y otros datos que
-no se solicitan al crear el recibo.
+un e-receipt en una factura. Si el recibo ya tiene un cliente asignado, puedes omitir
+el parámetro `customer`; de lo contrario, debes enviar el ID de un cliente existente
+o los datos del cliente para crearlo.
+
+Cuando envías `customer`, ese valor se usa como cliente receptor de la factura y
+sobrescribe el cliente que pudiera tener asignado el recibo.
 
 <Tabs groupId="codeExamples">
 <TabItem value="js" label="Node.js" default>
@@ -234,3 +238,16 @@ curl https://www.facturapi.io/v2/receipts/5ebd8e56f5687a013ca0df46/invoice \
 
 </TabItem>
 </Tabs>
+
+## Facturar múltiples recibos
+
+El método [Facturar múltiples recibos](/api/#tag/receipt/operation/createToInvoiceFromReceipts)
+crea una sola factura a partir de recibos abiertos seleccionados por `key`.
+
+El campo `customer` es opcional sólo cuando todos los recibos incluidos ya tienen
+asignado el mismo cliente. Si lo envías, Facturapi usará ese cliente para la factura
+y actualizará los recibos incluidos con ese cliente. Si no lo envías y los recibos
+tienen clientes distintos, o si algunos no tienen cliente asignado, la operación fallará.
+
+Las mismas reglas aplican para `dry_run` y para la vista previa en PDF. En esos casos
+Facturapi valida la operación como si fuera a crear la factura, pero no persiste cambios.

--- a/website/docs/guides/receipts.mdx
+++ b/website/docs/guides/receipts.mdx
@@ -19,10 +19,6 @@ donde podrán llenar sus datos fiscales y descargar su facuta (portal de autofac
 También puedes crear una factura global al final del mes que incluya todos aquellos
 recibos que no fueron facturados.
 
-Cuando un recibo se incluye en una factura global, Facturapi usa el cliente genérico
-`PUBLICO EN GENERAL` como receptor de la factura y actualiza los recibos incluidos
-con ese cliente.
-
 ## Crear un recibo
 
 Para ver las descripciones de todos los parámetros, consulta la referencia completa del
@@ -142,10 +138,20 @@ curl https://www.facturapi.io/v2/receipts \
 </TabItem>
 </Tabs>
 
-## Asignar un cliente a un recibo existente
+## Cliente asociado al recibo
 
-Puedes asignar o reasignar un cliente a un recibo existente con el método
-[Asignar cliente a recibo](/api/#tag/receipt/operation/assignReceiptCustomer).
+Un recibo puede existir sin cliente asociado. Ese estado significa que el destino de
+facturación todavía no está decidido: el recibo puede terminar en una autofactura, en
+una factura a un cliente específico o en una factura global.
+
+Puedes asociar un cliente al recibo desde el método
+[Crear Recibo](/api/#tag/receipt/operation/createReceipt), enviando el campo
+`customer`, o después con
+[Asignar o reasignar cliente a recibo](/api/#tag/receipt/operation/assignReceiptCustomer).
+En ambos casos puedes enviar el ID de un cliente existente o un objeto para crear uno nuevo.
+
+Al reasignar un cliente, Facturapi también actualiza la transacción asociada al recibo,
+si existe.
 
 ```bash
 curl https://www.facturapi.io/v2/receipts/58e93bd8e86eb318b019743d \
@@ -156,6 +162,23 @@ curl https://www.facturapi.io/v2/receipts/58e93bd8e86eb318b019743d \
         "customer": "58e93bd8e86eb318b0197456"
   }'
 ```
+
+Estas son las reglas al facturar recibos:
+
+- [Facturar un recibo](/api/#tag/receipt/operation/invoiceReceipt): si envías
+  `customer`, ese cliente se usa como receptor de la factura y sobrescribe el cliente
+  asignado previamente al recibo. Si omites `customer`, el recibo debe tener un cliente
+  asignado.
+- [Facturar múltiples recibos](/api/#tag/receipt/operation/createToInvoiceFromReceipts):
+  si envías `customer`, ese cliente se usa para todos los recibos incluidos. Si omites
+  `customer`, todos los recibos deben tener asignado el mismo cliente; si hay clientes
+  distintos o recibos sin cliente, la operación falla.
+- [Vista previa PDF de factura múltiple](/api/#tag/receipt/operation/previewToInvoiceFromReceipts)
+  y `dry_run` validan las mismas reglas de cliente que la creación real, pero no
+  persisten cambios.
+- [Factura global](/api/#tag/receipt/operation/createGlobalInvoice): Facturapi usa el
+  cliente genérico `PUBLICO EN GENERAL` como receptor y actualiza los recibos incluidos
+  con ese cliente.
 
 ## Portal de Autofactura
 
@@ -168,12 +191,8 @@ Para más información consulta el artículo de [Autofactura](/docs/guides/self-
 ## Facturar un recibo
 
 Por medio del método [Facturar Recibo](/api/#tag/receipt/operation/invoiceReceipt) puedes convertir
-un e-receipt en una factura. Si el recibo ya tiene un cliente asignado, puedes omitir
-el parámetro `customer`; de lo contrario, debes enviar el ID de un cliente existente
-o los datos del cliente para crearlo.
-
-Cuando envías `customer`, ese valor se usa como cliente receptor de la factura y
-sobrescribe el cliente que pudiera tener asignado el recibo.
+un e-receipt en una factura. Consulta las reglas de `customer` en la sección
+[Cliente asociado al recibo](#cliente-asociado-al-recibo).
 
 <Tabs groupId="codeExamples">
 <TabItem value="js" label="Node.js" default>
@@ -248,10 +267,5 @@ curl https://www.facturapi.io/v2/receipts/5ebd8e56f5687a013ca0df46/invoice \
 El método [Facturar múltiples recibos](/api/#tag/receipt/operation/createToInvoiceFromReceipts)
 crea una sola factura a partir de recibos abiertos seleccionados por `key`.
 
-El campo `customer` es opcional sólo cuando todos los recibos incluidos ya tienen
-asignado el mismo cliente. Si lo envías, Facturapi usará ese cliente para la factura
-y actualizará los recibos incluidos con ese cliente. Si no lo envías y los recibos
-tienen clientes distintos, o si algunos no tienen cliente asignado, la operación fallará.
-
-Las mismas reglas aplican para `dry_run` y para la vista previa en PDF. En esos casos
-Facturapi valida la operación como si fuera a crear la factura, pero no persiste cambios.
+Consulta las reglas de `customer`, `dry_run` y vista previa PDF en la sección
+[Cliente asociado al recibo](#cliente-asociado-al-recibo).

--- a/website/docs/guides/receipts.mdx
+++ b/website/docs/guides/receipts.mdx
@@ -19,6 +19,10 @@ donde podrán llenar sus datos fiscales y descargar su facuta (portal de autofac
 También puedes crear una factura global al final del mes que incluya todos aquellos
 recibos que no fueron facturados.
 
+Cuando un recibo se incluye en una factura global, Facturapi usa el cliente genérico
+`PUBLICO EN GENERAL` como receptor de la factura y actualiza los recibos incluidos
+con ese cliente.
+
 ## Crear un recibo
 
 Para ver las descripciones de todos los parámetros, consulta la referencia completa del

--- a/website/docs/guides/receipts.mdx
+++ b/website/docs/guides/receipts.mdx
@@ -192,8 +192,9 @@ factura global a `PUBLICO EN GENERAL`.
 ### Facturar un recibo
 
 Por medio del método [Facturar Recibo](/api/#tag/receipt/operation/invoiceReceipt) puedes convertir
-un e-receipt en una factura. Consulta las reglas completas en la sección
-[Formas de facturar recibos](#formas-de-facturar-recibos).
+un e-receipt en una factura a un cliente específico. Si el recibo ya tiene un cliente
+asignado, puedes omitir `customer`; si envías `customer`, ese cliente será el receptor
+de la factura.
 
 <Tabs groupId="codeExamples">
 <TabItem value="js" label="Node.js" default>
@@ -268,5 +269,5 @@ curl https://www.facturapi.io/v2/receipts/5ebd8e56f5687a013ca0df46/invoice \
 El método [Facturar múltiples recibos](/api/#tag/receipt/operation/createToInvoiceFromReceipts)
 crea una sola factura a partir de recibos abiertos seleccionados por `key`.
 
-Consulta las reglas completas en la sección
-[Formas de facturar recibos](#formas-de-facturar-recibos).
+También puedes enviar `dry_run: true` para validar la operación y obtener un resumen
+sin crear la factura, o usar la [vista previa PDF](/api/#tag/receipt/operation/previewToInvoiceFromReceipts).

--- a/website/i18n/en/docusaurus-plugin-content-docs/current/guides/receipts.mdx
+++ b/website/i18n/en/docusaurus-plugin-content-docs/current/guides/receipts.mdx
@@ -20,10 +20,6 @@ website where they can fill in their tax information and download their invoice
 You can also create a global invoice at the end of the month that includes all those
 receipts that were not invoiced (known as global invoice).
 
-When a receipt is included in a global invoice, Facturapi uses the generic
-`PUBLICO EN GENERAL` customer as the invoice recipient and updates the included
-receipts with that customer.
-
 ## Create a receipt
 
 To see the descriptions of all the parameters, consult the complete reference of the
@@ -143,10 +139,20 @@ curl https://www.facturapi.io/v2/receipts \
 </TabItem>
 </Tabs>
 
-## Assign a customer to an existing receipt
+## Receipt customer
 
-You can assign or reassign a customer (or create it from payload) to an existing receipt with
-[Assign customer to receipt](/api/#tag/receipt/operation/assignReceiptCustomer).
+A receipt can exist without an assigned customer. This state means the invoicing
+destination is not decided yet: the receipt can later become a self-invoice, an invoice
+to a specific customer, or part of a global invoice.
+
+You can associate a customer when calling
+[Create Receipt](/api/#tag/receipt/operation/createReceipt), by sending the
+`customer` field, or later with
+[Assign or reassign customer to receipt](/api/#tag/receipt/operation/assignReceiptCustomer).
+In both cases, you can send the ID of an existing customer or a customer object to create one.
+
+When you reassign a customer, Facturapi also updates the transaction associated with
+the receipt, if one exists.
 
 ```bash
 curl https://www.facturapi.io/v2/receipts/58e93bd8e86eb318b019743d \
@@ -157,6 +163,23 @@ curl https://www.facturapi.io/v2/receipts/58e93bd8e86eb318b019743d \
         "customer": "58e93bd8e86eb318b0197456"
       }'
 ```
+
+These are the rules when invoicing receipts:
+
+- [Convert e-receipt to invoice](/api/#tag/receipt/operation/invoiceReceipt): if you
+  send `customer`, that customer is used as the invoice recipient and overrides the
+  customer previously assigned to the receipt. If you omit `customer`, the receipt must
+  already have an assigned customer.
+- [Create invoice from multiple receipts](/api/#tag/receipt/operation/createToInvoiceFromReceipts):
+  if you send `customer`, that customer is used for every included receipt. If you omit
+  `customer`, all receipts must already have the same assigned customer; if they have
+  different customers or any receipt has no customer, the operation fails.
+- [PDF preview for multiple receipts invoice](/api/#tag/receipt/operation/previewToInvoiceFromReceipts)
+  and `dry_run` validate the same customer rules as real invoice creation, but do not
+  persist changes.
+- [Global invoice](/api/#tag/receipt/operation/createGlobalInvoice): Facturapi uses
+  the generic `PUBLICO EN GENERAL` customer as the invoice recipient and updates the
+  included receipts with that customer.
 
 ## Self-invoice portal
 
@@ -169,12 +192,8 @@ For more information, see the article on [Self-Invoice](/docs/guides/self-invoic
 ## Convert an e-receipt into an invoice
 
 With [Convert e-receipt to invoice](/api/#tag/receipt/operation/invoiceReceipt)
-you can convert an e-receipt into an invoice. If the receipt already has an
-assigned customer, you can omit the `customer` parameter; otherwise, send the ID
-of an existing customer or the customer data to create it.
-
-When you send `customer`, that value is used as the invoice recipient and
-overrides any customer previously assigned to the receipt.
+you can convert an e-receipt into an invoice. See the `customer` rules in
+[Receipt customer](#receipt-customer).
 
 <Tabs groupId="codeExamples">
 <TabItem value="js" label="Node.js" default>
@@ -249,12 +268,5 @@ curl https://www.facturapi.io/v2/receipts/5ebd8e56f5687a013ca0df46/invoice \
 [Create invoice from multiple receipts](/api/#tag/receipt/operation/createToInvoiceFromReceipts)
 creates a single invoice from open receipts selected by `key`.
 
-The `customer` field is optional only when every included receipt already has
-the same assigned customer. If you send `customer`, Facturapi uses it for the
-invoice and updates the included receipts with that customer. If you omit it and
-the receipts have different customers, or if some receipts do not have an
-assigned customer, the operation fails.
-
-The same rules apply to `dry_run` and to the PDF preview. In those cases,
-Facturapi validates the operation as if it were going to create the invoice, but
-does not persist changes.
+See the `customer`, `dry_run`, and PDF preview rules in
+[Receipt customer](#receipt-customer).

--- a/website/i18n/en/docusaurus-plugin-content-docs/current/guides/receipts.mdx
+++ b/website/i18n/en/docusaurus-plugin-content-docs/current/guides/receipts.mdx
@@ -145,7 +145,7 @@ curl https://www.facturapi.io/v2/receipts \
 
 ## Assign a customer to an existing receipt
 
-You can assign a customer (or create it from payload) to an existing receipt with
+You can assign or reassign a customer (or create it from payload) to an existing receipt with
 [Assign customer to receipt](/api/#tag/receipt/operation/assignReceiptCustomer).
 
 ```bash

--- a/website/i18n/en/docusaurus-plugin-content-docs/current/guides/receipts.mdx
+++ b/website/i18n/en/docusaurus-plugin-content-docs/current/guides/receipts.mdx
@@ -190,7 +190,7 @@ to `PUBLICO EN GENERAL`.
   customer. Included receipts are associated with that customer and their `status`
   changes to `"invoiced_globally"`.
 
-## Convert an e-receipt into an invoice
+### Convert an e-receipt into an invoice
 
 With [Convert e-receipt to invoice](/api/#tag/receipt/operation/invoiceReceipt)
 you can convert an e-receipt into an invoice. See the full rules in
@@ -264,7 +264,7 @@ curl https://www.facturapi.io/v2/receipts/5ebd8e56f5687a013ca0df46/invoice \
 </TabItem>
 </Tabs>
 
-## Convert multiple receipts into one invoice
+### Convert multiple receipts into one invoice
 
 [Create invoice from multiple receipts](/api/#tag/receipt/operation/createToInvoiceFromReceipts)
 creates a single invoice from open receipts selected by `key`.

--- a/website/i18n/en/docusaurus-plugin-content-docs/current/guides/receipts.mdx
+++ b/website/i18n/en/docusaurus-plugin-content-docs/current/guides/receipts.mdx
@@ -20,6 +20,10 @@ website where they can fill in their tax information and download their invoice
 You can also create a global invoice at the end of the month that includes all those
 receipts that were not invoiced (known as global invoice).
 
+When a receipt is included in a global invoice, Facturapi uses the generic
+`PUBLICO EN GENERAL` customer as the invoice recipient and updates the included
+receipts with that customer.
+
 ## Create a receipt
 
 To see the descriptions of all the parameters, consult the complete reference of the

--- a/website/i18n/en/docusaurus-plugin-content-docs/current/guides/receipts.mdx
+++ b/website/i18n/en/docusaurus-plugin-content-docs/current/guides/receipts.mdx
@@ -164,9 +164,13 @@ For more information, see the article on [Self-Invoice](/docs/guides/self-invoic
 
 ## Convert an e-receipt into an invoice
 
-Por medio del método [Facturar Recibo](/api/#tag/receipt/operation/invoiceReceipt) puedes convertir
-un e-receipt en una factura. Para ello, debes enviar los datos del cliente y otros datos que
-no se solicitan al crear el recibo.
+With [Convert e-receipt to invoice](/api/#tag/receipt/operation/invoiceReceipt)
+you can convert an e-receipt into an invoice. If the receipt already has an
+assigned customer, you can omit the `customer` parameter; otherwise, send the ID
+of an existing customer or the customer data to create it.
+
+When you send `customer`, that value is used as the invoice recipient and
+overrides any customer previously assigned to the receipt.
 
 <Tabs groupId="codeExamples">
 <TabItem value="js" label="Node.js" default>
@@ -235,3 +239,18 @@ curl https://www.facturapi.io/v2/receipts/5ebd8e56f5687a013ca0df46/invoice \
 
 </TabItem>
 </Tabs>
+
+## Convert multiple receipts into one invoice
+
+[Create invoice from multiple receipts](/api/#tag/receipt/operation/createToInvoiceFromReceipts)
+creates a single invoice from open receipts selected by `key`.
+
+The `customer` field is optional only when every included receipt already has
+the same assigned customer. If you send `customer`, Facturapi uses it for the
+invoice and updates the included receipts with that customer. If you omit it and
+the receipts have different customers, or if some receipts do not have an
+assigned customer, the operation fails.
+
+The same rules apply to `dry_run` and to the PDF preview. In those cases,
+Facturapi validates the operation as if it were going to create the invoice, but
+does not persist changes.

--- a/website/i18n/en/docusaurus-plugin-content-docs/current/guides/receipts.mdx
+++ b/website/i18n/en/docusaurus-plugin-content-docs/current/guides/receipts.mdx
@@ -150,9 +150,6 @@ You can associate a customer when calling
 [Assign or reassign customer to receipt](/api/#tag/receipt/operation/assignReceiptCustomer).
 In both cases, you can send the ID of an existing customer or a customer object to create one.
 
-When you reassign a customer, Facturapi also updates the transaction associated with
-the receipt, if one exists.
-
 ```bash
 curl https://www.facturapi.io/v2/receipts/58e93bd8e86eb318b019743d \
   -H "Authorization: Bearer sk_test_API_KEY" \

--- a/website/i18n/en/docusaurus-plugin-content-docs/current/guides/receipts.mdx
+++ b/website/i18n/en/docusaurus-plugin-content-docs/current/guides/receipts.mdx
@@ -193,8 +193,9 @@ to `PUBLICO EN GENERAL`.
 ### Convert an e-receipt into an invoice
 
 With [Convert e-receipt to invoice](/api/#tag/receipt/operation/invoiceReceipt)
-you can convert an e-receipt into an invoice. See the full rules in
-[Ways to invoice receipts](#ways-to-invoice-receipts).
+you can convert an e-receipt into an invoice for a specific customer. If the receipt
+already has an assigned customer, you can omit `customer`; if you send `customer`, that
+customer becomes the invoice recipient.
 
 <Tabs groupId="codeExamples">
 <TabItem value="js" label="Node.js" default>
@@ -269,4 +270,5 @@ curl https://www.facturapi.io/v2/receipts/5ebd8e56f5687a013ca0df46/invoice \
 [Create invoice from multiple receipts](/api/#tag/receipt/operation/createToInvoiceFromReceipts)
 creates a single invoice from open receipts selected by `key`.
 
-See the full rules in [Ways to invoice receipts](#ways-to-invoice-receipts).
+You can also send `dry_run: true` to validate the operation and get a summary without
+creating the invoice, or use the [PDF preview](/api/#tag/receipt/operation/previewToInvoiceFromReceipts).

--- a/website/i18n/en/docusaurus-plugin-content-docs/current/guides/receipts.mdx
+++ b/website/i18n/en/docusaurus-plugin-content-docs/current/guides/receipts.mdx
@@ -142,8 +142,7 @@ curl https://www.facturapi.io/v2/receipts \
 ## Receipt customer
 
 A receipt can exist without an assigned customer. This state means the invoicing
-destination is not decided yet: the receipt can later become a self-invoice, an invoice
-to a specific customer, or part of a global invoice.
+destination is not decided yet.
 
 You can associate a customer when calling
 [Create Receipt](/api/#tag/receipt/operation/createReceipt), by sending the
@@ -164,23 +163,6 @@ curl https://www.facturapi.io/v2/receipts/58e93bd8e86eb318b019743d \
       }'
 ```
 
-These are the rules when invoicing receipts:
-
-- [Convert e-receipt to invoice](/api/#tag/receipt/operation/invoiceReceipt): if you
-  send `customer`, that customer is used as the invoice recipient and overrides the
-  customer previously assigned to the receipt. If you omit `customer`, the receipt must
-  already have an assigned customer.
-- [Create invoice from multiple receipts](/api/#tag/receipt/operation/createToInvoiceFromReceipts):
-  if you send `customer`, that customer is used for every included receipt. If you omit
-  `customer`, all receipts must already have the same assigned customer; if they have
-  different customers or any receipt has no customer, the operation fails.
-- [PDF preview for multiple receipts invoice](/api/#tag/receipt/operation/previewToInvoiceFromReceipts)
-  and `dry_run` validate the same customer rules as real invoice creation, but do not
-  persist changes.
-- [Global invoice](/api/#tag/receipt/operation/createGlobalInvoice): Facturapi uses
-  the generic `PUBLICO EN GENERAL` customer as the invoice recipient and updates the
-  included receipts with that customer.
-
 ## Self-invoice portal
 
 When you create an e-receipt, you have the option to send it via email to your customer.
@@ -189,11 +171,33 @@ their tax information and download their invoice.
 
 For more information, see the article on [Self-Invoice](/docs/guides/self-invoice).
 
+## Ways to invoice receipts
+
+Open receipts can be invoiced to a specific customer or included in a global invoice
+to `PUBLICO EN GENERAL`.
+
+- [Convert e-receipt to invoice](/api/#tag/receipt/operation/invoiceReceipt) creates
+  an invoice for a single receipt. If you send `customer`, that customer is used as the
+  invoice recipient and overrides the customer previously assigned to the receipt. If
+  you omit `customer`, the receipt must already have an assigned customer.
+- [Create invoice from multiple receipts](/api/#tag/receipt/operation/createToInvoiceFromReceipts)
+  creates an invoice for several receipts selected by `key`. If you send `customer`,
+  that customer is used for every included receipt. If you omit `customer`, all receipts
+  must already have the same assigned customer; if they have different customers or any
+  receipt has no customer, the operation fails.
+- [PDF preview for multiple receipts invoice](/api/#tag/receipt/operation/previewToInvoiceFromReceipts)
+  and `dry_run` validate the same customer rules as real invoice creation, but do not
+  persist changes.
+- [Global invoice](/api/#tag/receipt/operation/createGlobalInvoice) also groups
+  multiple receipts, but always invoices them to the generic `PUBLICO EN GENERAL`
+  customer. Included receipts are associated with that customer and their `status`
+  changes to `"invoiced_globally"`.
+
 ## Convert an e-receipt into an invoice
 
 With [Convert e-receipt to invoice](/api/#tag/receipt/operation/invoiceReceipt)
-you can convert an e-receipt into an invoice. See the `customer` rules in
-[Receipt customer](#receipt-customer).
+you can convert an e-receipt into an invoice. See the full rules in
+[Ways to invoice receipts](#ways-to-invoice-receipts).
 
 <Tabs groupId="codeExamples">
 <TabItem value="js" label="Node.js" default>
@@ -268,5 +272,4 @@ curl https://www.facturapi.io/v2/receipts/5ebd8e56f5687a013ca0df46/invoice \
 [Create invoice from multiple receipts](/api/#tag/receipt/operation/createToInvoiceFromReceipts)
 creates a single invoice from open receipts selected by `key`.
 
-See the `customer`, `dry_run`, and PDF preview rules in
-[Receipt customer](#receipt-customer).
+See the full rules in [Ways to invoice receipts](#ways-to-invoice-receipts).

--- a/website/openapi_v2.en.yaml
+++ b/website/openapi_v2.en.yaml
@@ -5310,6 +5310,10 @@ paths:
         Creates a new invoice from a receipt. Once invoiced, the receipt's `status` will change to `"invoiced_to_customer"`.
 
         Only open receipts (`status = "open"`) can be invoiced.
+
+        If you send `customer`, that customer is used as the invoice recipient
+        and overrides the customer assigned to the receipt. If you omit
+        `customer`, the receipt must already have an assigned customer.
       x-codeSamples:
         - lang: Bash
           label: cURL
@@ -5405,7 +5409,12 @@ paths:
       description: |
         Creates a single invoice from multiple receipts selected by their `key`.
 
+        If you send `customer`, that customer is used as the invoice recipient
+        and overrides the customer assigned to the included receipts. If you omit
+        `customer`, all receipts must already have the same assigned customer.
+
         If `dry_run` is `true`, the endpoint does not create the invoice and returns a summary preview.
+        The `dry_run` validates the same rules as real invoice creation, but does not persist changes.
       x-codeSamples:
         - lang: Bash
           label: cURL
@@ -5542,6 +5551,9 @@ paths:
       summary: Preview PDF for multiple receipts invoice
       description: |
         Generates a PDF preview for an invoice built from multiple receipts selected by their `key`.
+
+        The preview validates the same customer rules as real invoice creation:
+        if you omit `customer`, all receipts must already have the same assigned customer.
       x-codeSamples:
         - lang: Bash
           label: cURL
@@ -15885,14 +15897,14 @@ components:
                 $ref: "#/components/schemas/Receipt"
     InvoiceReceiptInput:
       type: object
-      required:
-        - customer
       allOf:
         - type: object
           properties:
             customer:
               description: |
-                Customer receiving the invoice. You can send the customer object directly or the ID of a previously registered customer in Facturapi.
+                Customer receiving the invoice. You can send the customer object directly
+                or the ID of a previously registered customer in Facturapi. If you omit it,
+                the receipt must already have an assigned customer.
               oneOf:
                 - $ref: "#/components/schemas/CustomerCreateInput"
                 - type: string
@@ -16009,10 +16021,16 @@ components:
             description: Receipt key.
             example: ticket_1001
         customer:
-          allOf:
+          oneOf:
             - $ref: "#/components/schemas/CustomerCreateInput"
+            - type: string
+              title: customer_id
+              description: ID of a customer previously registered in Facturapi.
+              example: 58e93bd8e86eb318b0197456
           description: |
-            Customer receiving the invoice. Required unless `dry_run` is `true`.
+            Customer receiving the invoice. If you send it, it overrides the customer
+            assigned to the included receipts. If you omit it, all receipts must already
+            have the same assigned customer. This rule also applies when `dry_run` is `true`.
         use:
           type: string
           default: G01
@@ -16045,9 +16063,15 @@ components:
             example: ticket_1001
         customer:
           nullable: true
-          allOf:
+          oneOf:
             - $ref: "#/components/schemas/CustomerCreateInput"
-          description: Optional customer information used for preview rendering.
+            - type: string
+              title: customer_id
+              description: ID of a customer previously registered in Facturapi.
+              example: 58e93bd8e86eb318b0197456
+          description: |
+            Optional customer used for preview rendering. If you omit it, all receipts
+            must already have the same assigned customer.
         use:
           type: string
           default: G01

--- a/website/openapi_v2.en.yaml
+++ b/website/openapi_v2.en.yaml
@@ -4865,8 +4865,6 @@ paths:
       summary: Assign or reassign customer to receipt
       description: |
         Assign or reassign an existing customer (by ID) to a receipt, or create a new one by sending the customer object.
-
-        If the receipt has a registered transaction, the transaction's `counterparty` will also be updated.
       x-codeSamples:
         - lang: Bash
           label: cURL

--- a/website/openapi_v2.en.yaml
+++ b/website/openapi_v2.en.yaml
@@ -5680,6 +5680,10 @@ paths:
       summary: Create global invoice
       description: |
         Creates a global invoice that will include all receipts with `status = "open"` from a certain period.
+
+        Global invoices are issued to the generic `PUBLICO EN GENERAL` customer.
+        Included receipts are associated with that customer and their `status`
+        changes to `"invoiced_globally"`.
       x-codeSamples:
         - lang: Bash
           label: cURL

--- a/website/openapi_v2.en.yaml
+++ b/website/openapi_v2.en.yaml
@@ -4862,9 +4862,9 @@ paths:
       operationId: assignReceiptCustomer
       tags:
         - receipt
-      summary: Assign customer to receipt
+      summary: Assign or reassign customer to receipt
       description: |
-        Assign an existing customer (by ID) to a receipt, or create a new one by sending the customer object.
+        Assign or reassign an existing customer (by ID) to a receipt, or create a new one by sending the customer object.
 
         If the receipt has a registered transaction, the transaction's `counterparty` will also be updated.
       x-codeSamples:
@@ -15883,7 +15883,7 @@ components:
       properties:
         customer:
           description: |
-            Customer to assign to the receipt. You can send the ID of an existing customer or a customer object to create it.
+            Customer to assign or reassign to the receipt. You can send the ID of an existing customer or a customer object to create it.
           oneOf:
             - type: string
               minLength: 24

--- a/website/openapi_v2.yaml
+++ b/website/openapi_v2.yaml
@@ -5078,9 +5078,9 @@ paths:
       operationId: assignReceiptCustomer
       tags:
         - receipt
-      summary: Asignar cliente a recibo
+      summary: Asignar o reasignar cliente a recibo
       description: |
-        Asigna un cliente existente (por ID) a un recibo o crea uno nuevo enviando el objeto del cliente.
+        Asigna o reasigna un cliente existente (por ID) a un recibo, o crea uno nuevo enviando el objeto del cliente.
 
         Si el recibo tiene una transacción registrada, también se actualizará el `counterparty` de la transacción.
       x-codeSamples:
@@ -16139,7 +16139,7 @@ components:
       properties:
         customer:
           description: |
-            Cliente a asignar al recibo. Puedes enviar el ID de un cliente existente o un objeto de cliente para crearlo.
+            Cliente a asignar o reasignar al recibo. Puedes enviar el ID de un cliente existente o un objeto de cliente para crearlo.
           oneOf:
             - type: string
               minLength: 24

--- a/website/openapi_v2.yaml
+++ b/website/openapi_v2.yaml
@@ -5081,8 +5081,6 @@ paths:
       summary: Asignar o reasignar cliente a recibo
       description: |
         Asigna o reasigna un cliente existente (por ID) a un recibo, o crea uno nuevo enviando el objeto del cliente.
-
-        Si el recibo tiene una transacción registrada, también se actualizará el `counterparty` de la transacción.
       x-codeSamples:
         - lang: Bash
           label: cURL

--- a/website/openapi_v2.yaml
+++ b/website/openapi_v2.yaml
@@ -5525,6 +5525,10 @@ paths:
 
         Sólo pueden facturarse recibos abiertos (`status = "open"`)
 
+        Si envías `customer`, ese cliente se usará como receptor de la factura y
+        sobrescribirá el cliente asignado al recibo. Si omites `customer`, el
+        recibo debe tener un cliente asignado previamente.
+
         Una vez facturado, el `status` del recibo cambiará a `"invoiced_to_customer"`.
       x-codeSamples:
         - lang: Bash
@@ -5621,7 +5625,12 @@ paths:
       description: |
         Crea una sola factura a partir de múltiples recibos seleccionados por su `key`.
 
+        Si envías `customer`, ese cliente se usará como receptor de la factura y
+        sobrescribirá el cliente asignado a los recibos incluidos. Si omites
+        `customer`, todos los recibos deben tener asignado el mismo cliente.
+
         Si `dry_run` es `true`, no crea la factura y regresa un resumen de vista previa.
+        El `dry_run` valida las mismas reglas que la creación real, pero no persiste cambios.
       x-codeSamples:
         - lang: Bash
           label: cURL
@@ -5758,6 +5767,9 @@ paths:
       summary: Vista previa PDF de factura múltiple
       description: |
         Genera una vista previa en PDF para una factura construida a partir de múltiples recibos seleccionados por `key`.
+
+        La vista previa valida las mismas reglas de cliente que la creación real:
+        si omites `customer`, todos los recibos deben tener asignado el mismo cliente.
       x-codeSamples:
         - lang: Bash
           label: cURL
@@ -16141,13 +16153,14 @@ components:
                 $ref: "#/components/schemas/Receipt"
     InvoiceReceiptInput:
       type: object
-      required:
-        - customer
       allOf:
         - type: object
           properties:
             customer:
-              description: Cliente receptor de la factura.
+              description: |
+                Cliente receptor de la factura. Puedes enviarlo como ID de un cliente existente
+                o como objeto para crear un cliente nuevo. Si lo omites, el recibo debe tener
+                un cliente asignado previamente.
               oneOf:
                 - $ref: "#/components/schemas/CustomerCreateInput"
                 - type: string
@@ -16259,10 +16272,17 @@ components:
             description: Key del recibo.
             example: ticket_1001
         customer:
-          allOf:
+          oneOf:
             - $ref: "#/components/schemas/CustomerCreateInput"
+            - type: string
+              title: customer_id
+              description: ID de un cliente previamente registrado en Facturapi.
+              example: 58e93bd8e86eb318b0197456
           description: |
-            Cliente receptor de la factura. Requerido excepto cuando `dry_run` es `true`.
+            Cliente receptor de la factura. Si lo envías, sobrescribe el cliente
+            asignado a los recibos incluidos. Si lo omites, todos los recibos deben
+            tener asignado el mismo cliente. Esta regla también aplica cuando
+            `dry_run` es `true`.
         use:
           type: string
           default: G01
@@ -16295,9 +16315,15 @@ components:
             example: ticket_1001
         customer:
           nullable: true
-          allOf:
+          oneOf:
             - $ref: "#/components/schemas/CustomerCreateInput"
-          description: Información de cliente opcional para renderizar la vista previa.
+            - type: string
+              title: customer_id
+              description: ID de un cliente previamente registrado en Facturapi.
+              example: 58e93bd8e86eb318b0197456
+          description: |
+            Cliente opcional para renderizar la vista previa. Si lo omites,
+            todos los recibos deben tener asignado el mismo cliente.
         use:
           type: string
           default: G01

--- a/website/openapi_v2.yaml
+++ b/website/openapi_v2.yaml
@@ -5896,6 +5896,10 @@ paths:
       summary: Crear factura global
       description: |
         Crea una factura global que incluirá todos los recibos con `status = “open”` de un cierto periodo.
+
+        La factura global se emite al cliente genérico `PUBLICO EN GENERAL`.
+        Los recibos incluidos quedan asociados a ese cliente y su `status`
+        cambia a `"invoiced_globally"`.
       x-codeSamples:
         - lang: Bash
           label: cURL


### PR DESCRIPTION
## Objetivo

Explicar cómo funcionan las asignaciones de cliente en recibos y las distintas formas de facturarlos.

## Cambios

- Agrega la sección `Cliente asociado al recibo` para explicar que un recibo puede existir sin cliente, crearse con cliente o reasignarse después.
- Agrega la sección `Formas de facturar recibos` para comparar facturar a un cliente específico contra factura global a `PUBLICO EN GENERAL`.
- Menciona los endpoints relevantes: crear recibo, asignar/reasignar cliente, facturar un recibo, facturar múltiples recibos, vista previa PDF y factura global.
- Aclara cuándo `customer` puede omitirse y cuándo sobrescribe el cliente previo.
- Explica que `dry_run` y la vista previa PDF siguen las mismas reglas de cliente que la creación real, sin guardar cambios.
- Explica que factura global también agrupa múltiples recibos, pero siempre los factura a `PUBLICO EN GENERAL`.
- La referencia OpenAPI v2 en español e inglés refleja las mismas reglas en los campos y endpoints correspondientes.

## Validación

- `git diff --check`
- `ruby -ryaml -e "ARGV.each { |f| YAML.load_file(f); puts \"#{f} ok\" }" website/openapi_v2.yaml website/openapi_v2.en.yaml`
