### PR TITLE
Códigos de error consistentes y documentados

### DIFF
--- a/website/docs/getting-started/errors.mdx
+++ b/website/docs/getting-started/errors.mdx
@@ -5,7 +5,7 @@ sidebar_position: 7
 # Manejo de errores
 
 :::info Vigencia
-Los códigos y mensajes de error normalizados descritos aquí aplicarán a partir del 30 de junio de 2026.
+Los códigos y mensajes de error normalizados descritos aquí aplicarán a partir del 30 de junio de 2026. Antes de esa fecha, los códigos y mensajes pueden ser diferentes a los documentados en esta página.
 :::
 
 La API responde los errores en JSON y usa códigos de estado HTTP estándar. Para manejar errores de forma programática, usa `code`: es un string estable y predecible.
@@ -87,6 +87,8 @@ Cuando alcanzas un límite, la API responde `429 Too Many Requests`, `code: "rat
 También puedes conservar el header `X-Facturapi-Log-Id` en tu observabilidad para correlacionar solicitudes con soporte.
 
 ## Códigos de error
+
+Esta lista es la referencia documentada de códigos públicos de la API. Podemos agregar nuevos códigos en cualquier momento cuando nuevas funcionalidades o nuevos casos de error lo requieran, pero procuramos mantener esta página actualizada para que las integraciones tengan una referencia predecible.
 
 ### CommonErrorCode
 

--- a/website/docs/getting-started/errors.mdx
+++ b/website/docs/getting-started/errors.mdx
@@ -33,15 +33,15 @@ La API responde los errores en JSON y usa códigos de estado HTTP estándar. Par
 }
 ```
 
-| Campo | Descripción |
-| --- | --- |
-| `message` | Mensaje legible para humanos. |
-| `status` | Código de estado HTTP. |
-| `code` | Código raíz estable para manejar el error. |
-| `location` | Ubicación del dato relacionado con el error, por ejemplo `body`, `query`, `params` o `files`. Sólo se incluye cuando aplica. |
-| `path` | Ruta del campo relacionado con el error. Sólo se incluye cuando aplica. |
-| `errors` | Detalles adicionales. Sólo se incluye cuando hay múltiples errores de validación o detalles externos relevantes. |
-| `ok` | Siempre es `false` en respuestas de error. |
+| Campo | Tipo | Descripción |
+| --- | --- | --- |
+| `message` | `string` | Mensaje legible para humanos. |
+| `status` | `number` | Código de estado HTTP. |
+| `code` | `string` | Código raíz estable para manejar el error. |
+| `location` | `string` | Ubicación del dato relacionado con el error, por ejemplo `body`, `query`, `params` o `files`. Sólo se incluye cuando aplica. |
+| `path` | `string` | Ruta del campo relacionado con el error. Sólo se incluye cuando aplica. |
+| `errors` | `array` | Detalles adicionales. Sólo se incluye cuando hay múltiples errores de validación o detalles externos relevantes. |
+| `ok` | `boolean` | Siempre es `false` en respuestas de error. |
 
 ## Errores de validación
 

--- a/website/docs/getting-started/errors.mdx
+++ b/website/docs/getting-started/errors.mdx
@@ -1,0 +1,294 @@
+---
+sidebar_position: 7
+---
+
+# Manejo de errores
+
+:::info Vigencia
+Los códigos y mensajes de error normalizados descritos aquí aplicarán a partir del 30 de junio de 2026.
+:::
+
+La API responde los errores en JSON y usa códigos de estado HTTP estándar. Para manejar errores de forma programática, usa `code`: es un string estable y predecible.
+
+`message` está pensado para lectura humana. Puede cambiar para mejorar claridad o soportar localización, así que no debería usarse para branching de lógica.
+
+## Objeto de error
+
+```json
+{
+  "message": "La solicitud no es válida.",
+  "status": 400,
+  "code": "invalid_request",
+  "location": "body",
+  "path": "customer.email",
+  "errors": [
+    {
+      "message": "\"customer.email\" is required",
+      "code": "required",
+      "location": "body",
+      "path": "customer.email"
+    }
+  ],
+  "ok": false
+}
+```
+
+| Campo | Descripción |
+| --- | --- |
+| `message` | Mensaje legible para humanos. |
+| `status` | Código de estado HTTP. |
+| `code` | Código raíz estable para manejar el error. |
+| `location` | Ubicación del dato relacionado con el error, por ejemplo `body`, `query`, `params` o `files`. Sólo se incluye cuando aplica. |
+| `path` | Ruta del campo relacionado con el error. Sólo se incluye cuando aplica. |
+| `errors` | Detalles adicionales. Sólo se incluye cuando hay múltiples errores de validación o detalles externos relevantes. |
+| `ok` | Siempre es `false` en respuestas de error. |
+
+## Errores de validación
+
+Cuando la petición no cumple el contrato de entrada, el error raíz usa `code: "invalid_request"`. Si hay detalles, `errors[]` incluye cada campo inválido con `path`, `location` y un subcódigo de validación.
+
+Subcódigos de validación:
+
+- `invalid_format`
+- `invalid_length`
+- `invalid_type`
+- `not_allowed`
+- `required`
+- `too_large`
+- `too_small`
+- `unknown_field`
+
+## Errores externos
+
+Algunas operaciones dependen de validaciones o servicios externos, como SAT o PAC. En esos casos, el `code` raíz sigue siendo un código de Facturapi, por ejemplo `invoice_stamping_validation_error`.
+
+Si el proveedor externo devuelve detalles útiles, se incluyen en `errors[]` con su código original:
+
+```json
+{
+  "message": "La factura no pasó la validación de timbrado.",
+  "status": 400,
+  "code": "invoice_stamping_validation_error",
+  "errors": [
+    {
+      "message": "El RFC del receptor no se encuentra en la lista de RFC inscritos no cancelados del SAT.",
+      "code": "CFDI40145",
+      "source": "sat"
+    }
+  ],
+  "ok": false
+}
+```
+
+## Límites de tasa
+
+Cuando alcanzas un límite, la API responde `429 Too Many Requests`, `code: "rate_limit_exceeded"` y el header `Retry-After` con los segundos recomendados antes de reintentar.
+
+También puedes conservar el header `X-Facturapi-Log-Id` en tu observabilidad para correlacionar solicitudes con soporte.
+
+## Códigos de error
+
+### CommonErrorCode
+
+- `conflict`
+- `forbidden`
+- `internal_error`
+- `not_found`
+- `unauthorized`
+
+### AuthErrorCode
+
+- `api_key_invalid`
+- `api_key_not_allowed`
+- `feature_not_available`
+- `live_api_key_required`
+- `mcp_permission_denied`
+- `missing_credentials`
+- `organization_incomplete`
+- `subscription_required`
+- `subscription_live_access_required`
+- `user_key_invalid`
+- `user_suspended`
+
+### RequestErrorCode
+
+- `date_range_too_large`
+- `idempotency_key_in_use`
+- `image_file_required`
+- `invalid_country_code`
+- `invalid_date`
+- `invalid_date_range`
+- `invalid_image_file`
+- `invalid_json`
+- `invalid_multipart_form_data`
+- `invalid_request`
+- `invalid_state_code`
+- `invalid_timezone`
+- `multipart_limit_exceeded`
+- `page_too_large`
+- `payload_too_large`
+- `rate_limit_exceeded`
+
+### CustomerErrorCode
+
+- `customer_could_not_be_resolved`
+- `customer_edit_link_not_found`
+- `customer_edit_link_unavailable`
+- `customer_email_required`
+- `customer_has_invoices`
+- `customer_not_found`
+- `customer_tax_info_unavailable`
+
+### ProductErrorCode
+
+- `product_not_found`
+
+### SupplierErrorCode
+
+- `supplier_not_found`
+
+### CatalogErrorCode
+
+- `product_key_not_found`
+- `tariff_code_not_found`
+- `unit_key_not_found`
+
+### InvoiceErrorCode
+
+- `invoice_already_stamped`
+- `invoice_not_draft`
+- `invoice_not_found`
+- `invoice_not_stamped`
+
+### InvoiceDraftErrorCode
+
+- `draft_not_ready_to_stamp`
+- `draft_update_in_progress`
+
+### InvoiceStampingErrorCode
+
+- `invoice_stamping_failed`
+- `invoice_stamping_service_unavailable`
+- `invoice_stamping_validation_error`
+- `manifesto_signature_failed`
+- `stamping_in_progress`
+
+### InvoiceDeliveryErrorCode
+
+- `invoice_email_delivery_failed`
+- `invoice_email_recipient_required`
+- `invoice_email_status_not_allowed`
+
+### InvoiceCancellationErrorCode
+
+- `invoice_cancellation_failed`
+- `invoice_cancellation_in_progress`
+- `invoice_cancellation_not_allowed`
+- `invoice_cancellation_not_found`
+- `invoice_cancellation_receipt_unavailable`
+- `invoice_cancellation_rfc_mismatch`
+- `invoice_cancellation_service_unavailable`
+- `invoice_not_cancelable`
+- `invoice_not_cancelable_by_sat`
+- `substitution_invoice_canceled`
+- `substitution_invoice_not_found`
+- `substitution_invoice_required`
+- `substitution_invoice_status_not_allowed`
+
+### ReceiptErrorCode
+
+- `receipt_expired`
+- `receipt_not_found`
+- `receipt_not_open`
+
+### ReceiptInvoicingErrorCode
+
+- `receipt_invoicing_customer_mismatch`
+- `receipt_invoicing_too_many_items`
+- `receipt_keys_not_found`
+
+### ReceiptGlobalInvoiceErrorCode
+
+- `global_invoice_too_many_items`
+- `invalid_global_invoice_period`
+
+### RetentionErrorCode
+
+- `invalid_retention_complement`
+- `retention_not_cancelable`
+- `retention_not_found`
+- `retention_not_stamped`
+
+### RetentionDeliveryErrorCode
+
+- `retention_email_delivery_failed`
+- `retention_email_recipient_required`
+- `retention_email_status_not_allowed`
+
+### RetentionCancellationErrorCode
+
+- `retention_cancellation_failed`
+- `retention_cancellation_service_unavailable`
+
+### RetentionStampingErrorCode
+
+- `retention_stamping_failed`
+- `retention_stamping_service_unavailable`
+- `retention_stamping_validation_error`
+
+### OrganizationErrorCode
+
+- `invalid_operation`
+- `invalid_user_id`
+- `organization_not_found`
+- `subscription_active_required`
+
+### OrganizationSettingsErrorCode
+
+- `certificate_invalid`
+- `certificate_rfc_mismatch`
+- `fiel_invalid`
+- `fiel_rfc_mismatch`
+- `organization_settings_invalid`
+- `organization_tax_info_invalid`
+
+### OrganizationInviteErrorCode
+
+- `invite_email_delivery_failed`
+- `invite_email_mismatch`
+- `invite_expired`
+- `invite_not_found`
+- `invite_role_unavailable`
+- `user_already_in_organization`
+
+### OrganizationAccessErrorCode
+
+- `organization_admin_access_cannot_be_removed`
+- `organization_admin_assignment_cannot_be_edited`
+- `organization_admin_role_cannot_be_deleted`
+- `organization_admin_role_cannot_be_edited`
+- `organization_admin_role_required`
+- `organization_id_not_allowed`
+- `organization_id_required`
+- `owner_access_cannot_be_reassigned`
+- `owner_access_cannot_be_removed`
+- `role_has_assigned_users`
+- `role_not_found`
+- `role_template_not_found`
+- `user_access_not_found`
+
+### OrganizationSeriesErrorCode
+
+- `series_already_exists`
+- `series_not_found`
+
+### WebhookErrorCode
+
+- `webhook_delivery_attempt_not_found`
+- `webhook_not_found`
+- `webhook_signature_invalid`
+
+### ToolErrorCode
+
+- `tax_id_validation_failed`
+- `tax_id_validation_service_unavailable`

--- a/website/docs/getting-started/errors.mdx
+++ b/website/docs/getting-started/errors.mdx
@@ -49,14 +49,16 @@ Cuando la petición no cumple el contrato de entrada, el error raíz usa `code: 
 
 Subcódigos de validación:
 
-- `invalid_format`
-- `invalid_length`
-- `invalid_type`
-- `not_allowed`
-- `required`
-- `too_large`
-- `too_small`
-- `unknown_field`
+| Código | Descripción |
+| --- | --- |
+| `invalid_format` | El valor no cumple el formato esperado. |
+| `invalid_length` | El valor no cumple la longitud permitida. |
+| `invalid_type` | El valor no tiene el tipo esperado. |
+| `not_allowed` | El valor no está permitido para este campo. |
+| `required` | Falta un campo requerido. |
+| `too_large` | El valor excede el límite permitido. |
+| `too_small` | El valor está por debajo del mínimo permitido. |
+| `unknown_field` | El campo no está permitido en esta petición. |
 
 ## Errores externos
 
@@ -94,205 +96,257 @@ Esta lista es la referencia documentada de códigos públicos de la API. Podemos
 
 ### CommonErrorCode
 
-- `conflict`
-- `forbidden`
-- `internal_error`
-- `not_found`
-- `unauthorized`
+| Código | Descripción |
+| --- | --- |
+| `conflict` | La solicitud no puede completarse por un conflicto. |
+| `forbidden` | No tienes permiso para realizar esta acción. |
+| `internal_error` | Ocurrió un error interno. |
+| `not_found` | No se encontró el recurso solicitado. |
+| `unauthorized` | No se pudo autenticar la solicitud. |
 
 ### AuthErrorCode
 
-- `api_key_invalid`
-- `api_key_not_allowed`
-- `feature_not_available`
-- `live_api_key_required`
-- `mcp_permission_denied`
-- `missing_credentials`
-- `organization_incomplete`
-- `subscription_required`
-- `subscription_live_access_required`
-- `user_key_invalid`
-- `user_suspended`
+| Código | Descripción |
+| --- | --- |
+| `api_key_invalid` | La API key proporcionada no es válida. |
+| `api_key_not_allowed` | Esta API key no puede realizar esta acción. |
+| `feature_not_available` | Esta funcionalidad no está disponible para tu organización. |
+| `live_api_key_required` | Esta operación requiere una API key de producción. |
+| `mcp_permission_denied` | No tienes permiso para usar esta herramienta. |
+| `missing_credentials` | No se proporcionaron credenciales. |
+| `organization_incomplete` | La organización no está configurada para realizar esta operación. |
+| `subscription_required` | Esta operación requiere una suscripción activa. |
+| `subscription_live_access_required` | Tu suscripción no permite usar el ambiente de producción. |
+| `user_key_invalid` | La user key proporcionada no es válida. |
+| `user_suspended` | El usuario está suspendido. |
 
 ### RequestErrorCode
 
-- `date_range_too_large`
-- `idempotency_key_in_use`
-- `image_file_required`
-- `invalid_country_code`
-- `invalid_date`
-- `invalid_date_range`
-- `invalid_image_file`
-- `invalid_json`
-- `invalid_multipart_form_data`
-- `invalid_request`
-- `invalid_state_code`
-- `invalid_timezone`
-- `multipart_limit_exceeded`
-- `page_too_large`
-- `payload_too_large`
-- `rate_limit_exceeded`
+| Código | Descripción |
+| --- | --- |
+| `idempotency_key_in_use` | La idempotency key ya está siendo usada. |
+| `rate_limit_exceeded` | Se excedió el límite de solicitudes. |
+| `date_range_too_large` | El rango de fechas excede el límite permitido. |
+| `image_file_required` | Se requiere un archivo de imagen. |
+| `invalid_country_code` | El código de país no es válido. |
+| `invalid_date` | La fecha no es válida. |
+| `invalid_date_range` | El rango de fechas no es válido. |
+| `invalid_image_file` | El archivo proporcionado no es una imagen válida. |
+| `invalid_json` | El JSON enviado no es válido. |
+| `invalid_request` | La solicitud no es válida. |
+| `invalid_multipart_form_data` | Los datos multipart/form-data no son válidos. |
+| `invalid_state_code` | El código de estado no es válido. |
+| `invalid_timezone` | La zona horaria no es válida. |
+| `multipart_limit_exceeded` | La solicitud multipart/form-data excede los límites permitidos. |
+| `page_too_large` | La página solicitada excede el límite permitido. |
+| `payload_too_large` | El payload excede el tamaño máximo permitido. |
 
 ### CustomerErrorCode
 
-- `customer_could_not_be_resolved`
-- `customer_edit_link_not_found`
-- `customer_edit_link_unavailable`
-- `customer_email_required`
-- `customer_has_invoices`
-- `customer_not_found`
-- `customer_tax_info_unavailable`
+| Código | Descripción |
+| --- | --- |
+| `customer_could_not_be_resolved` | No se pudo resolver el cliente. |
+| `customer_edit_link_not_found` | El enlace de edición del cliente no existe o expiró. |
+| `customer_edit_link_unavailable` | El enlace de edición del cliente no está disponible. |
+| `customer_email_required` | Se requiere un correo electrónico del cliente. |
+| `customer_has_invoices` | No se puede eliminar un cliente con facturas asociadas. |
+| `customer_not_found` | No se encontró el cliente. |
+| `customer_tax_info_unavailable` | La información fiscal del cliente no está disponible. |
 
 ### ProductErrorCode
 
-- `product_not_found`
+| Código | Descripción |
+| --- | --- |
+| `product_not_found` | No se encontró el producto. |
 
 ### SupplierErrorCode
 
-- `supplier_not_found`
+| Código | Descripción |
+| --- | --- |
+| `supplier_not_found` | No se encontró el proveedor. |
 
 ### CatalogErrorCode
 
-- `product_key_not_found`
-- `tariff_code_not_found`
-- `unit_key_not_found`
+| Código | Descripción |
+| --- | --- |
+| `product_key_not_found` | No se encontró la clave de producto o servicio. |
+| `tariff_code_not_found` | No se encontró la fracción arancelaria. |
+| `unit_key_not_found` | No se encontró la clave de unidad. |
 
 ### InvoiceErrorCode
 
-- `invoice_already_stamped`
-- `invoice_not_draft`
-- `invoice_not_found`
-- `invoice_not_stamped`
+| Código | Descripción |
+| --- | --- |
+| `invoice_already_stamped` | La factura ya fue timbrada. |
+| `invoice_not_draft` | La factura no es un borrador. |
+| `invoice_not_found` | No se encontró la factura. |
+| `invoice_not_stamped` | La factura no ha sido timbrada. |
 
 ### InvoiceDraftErrorCode
 
-- `draft_not_ready_to_stamp`
-- `draft_update_in_progress`
+| Código | Descripción |
+| --- | --- |
+| `draft_not_ready_to_stamp` | El borrador no está listo para timbrarse. |
+| `draft_update_in_progress` | El borrador ya se está actualizando. |
 
 ### InvoiceStampingErrorCode
 
-- `invoice_stamping_failed`
-- `invoice_stamping_service_unavailable`
-- `invoice_stamping_validation_error`
-- `manifesto_signature_failed`
-- `stamping_in_progress`
+| Código | Descripción |
+| --- | --- |
+| `invoice_stamping_failed` | No se pudo timbrar la factura. |
+| `invoice_stamping_service_unavailable` | El servicio de timbrado no está disponible. |
+| `invoice_stamping_validation_error` | La factura no pasó la validación de timbrado. |
+| `manifesto_signature_failed` | No se pudo firmar el manifiesto. |
+| `stamping_in_progress` | El timbrado de esta factura ya está en proceso. |
 
 ### InvoiceDeliveryErrorCode
 
-- `invoice_email_delivery_failed`
-- `invoice_email_recipient_required`
-- `invoice_email_status_not_allowed`
+| Código | Descripción |
+| --- | --- |
+| `invoice_email_delivery_failed` | No se pudo enviar la factura por correo. |
+| `invoice_email_recipient_required` | No tenemos una dirección de correo electrónico registrada para este cliente. |
+| `invoice_email_status_not_allowed` | No se permite enviar una factura con status `{status}` por correo. |
 
 ### InvoiceCancellationErrorCode
 
-- `invoice_cancellation_failed`
-- `invoice_cancellation_in_progress`
-- `invoice_cancellation_not_allowed`
-- `invoice_cancellation_not_found`
-- `invoice_cancellation_receipt_unavailable`
-- `invoice_cancellation_rfc_mismatch`
-- `invoice_cancellation_service_unavailable`
-- `invoice_not_cancelable`
-- `invoice_not_cancelable_by_sat`
-- `substitution_invoice_canceled`
-- `substitution_invoice_not_found`
-- `substitution_invoice_required`
-- `substitution_invoice_status_not_allowed`
+| Código | Descripción |
+| --- | --- |
+| `invoice_cancellation_in_progress` | La factura tiene una solicitud de cancelación pendiente. |
+| `invoice_cancellation_receipt_unavailable` | El acuse de cancelación no está disponible. |
+| `invoice_cancellation_failed` | No se pudo cancelar la factura. |
+| `invoice_cancellation_not_allowed` | La cancelación de la factura no está permitida. |
+| `invoice_cancellation_not_found` | No se encontró la solicitud de cancelación. |
+| `invoice_cancellation_rfc_mismatch` | El RFC no coincide para cancelar la factura. |
+| `invoice_cancellation_service_unavailable` | El servicio de cancelación no está disponible. |
+| `invoice_not_cancelable` | La factura no puede cancelarse. |
+| `invoice_not_cancelable_by_sat` | La factura no puede cancelarse ante el SAT. |
+| `substitution_invoice_canceled` | La factura de sustitución ya está cancelada. |
+| `substitution_invoice_not_found` | No se encontró la factura de sustitución. |
+| `substitution_invoice_required` | Se requiere una factura de sustitución. |
+| `substitution_invoice_status_not_allowed` | La factura de sustitución no tiene un estatus válido. |
 
 ### ReceiptErrorCode
 
-- `receipt_expired`
-- `receipt_not_found`
-- `receipt_not_open`
+| Código | Descripción |
+| --- | --- |
+| `receipt_expired` | El recibo expiró. |
+| `receipt_not_found` | No se encontró el recibo. |
+| `receipt_not_open` | El recibo no está abierto. |
 
 ### ReceiptInvoicingErrorCode
 
-- `receipt_invoicing_customer_mismatch`
-- `receipt_invoicing_too_many_items`
-- `receipt_keys_not_found`
+| Código | Descripción |
+| --- | --- |
+| `receipt_invoicing_customer_mismatch` | Los recibos no pueden facturarse juntos para el mismo cliente. |
+| `receipt_invoicing_too_many_items` | Los recibos exceden el límite de conceptos permitidos. |
+| `receipt_keys_not_found` | No se encontraron todos los recibos solicitados. |
 
 ### ReceiptGlobalInvoiceErrorCode
 
-- `global_invoice_too_many_items`
-- `invalid_global_invoice_period`
+| Código | Descripción |
+| --- | --- |
+| `global_invoice_too_many_items` | La factura global excede el límite de conceptos permitidos. |
+| `invalid_global_invoice_period` | El periodo de factura global no es válido. |
 
 ### RetentionErrorCode
 
-- `invalid_retention_complement`
-- `retention_not_cancelable`
-- `retention_not_found`
-- `retention_not_stamped`
+| Código | Descripción |
+| --- | --- |
+| `invalid_retention_complement` | El complemento de retención no es válido. |
+| `retention_not_found` | No se encontró la retención. |
+| `retention_not_stamped` | La retención no ha sido timbrada. |
+| `retention_not_cancelable` | La retención no puede cancelarse. |
 
 ### RetentionDeliveryErrorCode
 
-- `retention_email_delivery_failed`
-- `retention_email_recipient_required`
-- `retention_email_status_not_allowed`
+| Código | Descripción |
+| --- | --- |
+| `retention_email_delivery_failed` | No se pudo enviar la retención por correo. |
+| `retention_email_recipient_required` | No tenemos una dirección de correo electrónico registrada para este cliente. |
+| `retention_email_status_not_allowed` | No se permite enviar una retención con status `{status}` por correo. |
 
 ### RetentionCancellationErrorCode
 
-- `retention_cancellation_failed`
-- `retention_cancellation_service_unavailable`
+| Código | Descripción |
+| --- | --- |
+| `retention_cancellation_failed` | No se pudo cancelar la retención. |
+| `retention_cancellation_service_unavailable` | El servicio de cancelación de retenciones no está disponible. |
 
 ### RetentionStampingErrorCode
 
-- `retention_stamping_failed`
-- `retention_stamping_service_unavailable`
-- `retention_stamping_validation_error`
+| Código | Descripción |
+| --- | --- |
+| `retention_stamping_failed` | No se pudo timbrar la retención. |
+| `retention_stamping_service_unavailable` | El servicio de timbrado de retenciones no está disponible. |
+| `retention_stamping_validation_error` | La retención no pasó la validación de timbrado. |
 
 ### OrganizationErrorCode
 
-- `invalid_operation`
-- `invalid_user_id`
-- `organization_not_found`
-- `subscription_active_required`
+| Código | Descripción |
+| --- | --- |
+| `invalid_operation` | La operación no es válida. |
+| `invalid_user_id` | El usuario no es válido. |
+| `organization_not_found` | No se encontró la organización. |
+| `subscription_active_required` | La organización requiere una suscripción activa. |
 
 ### OrganizationSettingsErrorCode
 
-- `certificate_invalid`
-- `certificate_rfc_mismatch`
-- `fiel_invalid`
-- `fiel_rfc_mismatch`
-- `organization_settings_invalid`
-- `organization_tax_info_invalid`
+| Código | Descripción |
+| --- | --- |
+| `certificate_invalid` | El certificado no es válido. |
+| `certificate_rfc_mismatch` | El RFC del certificado no coincide con la organización. |
+| `fiel_invalid` | La FIEL no es válida. |
+| `fiel_rfc_mismatch` | El RFC de la FIEL no coincide con la organización. |
+| `organization_settings_invalid` | La configuración de la organización no es válida. |
+| `organization_tax_info_invalid` | La información fiscal de la organización no es válida. |
 
 ### OrganizationInviteErrorCode
 
-- `invite_email_delivery_failed`
-- `invite_email_mismatch`
-- `invite_expired`
-- `invite_not_found`
-- `invite_role_unavailable`
-- `user_already_in_organization`
+| Código | Descripción |
+| --- | --- |
+| `invite_email_delivery_failed` | No se pudo enviar la invitación por correo. |
+| `invite_email_mismatch` | El correo no coincide con la invitación. |
+| `invite_expired` | La invitación expiró. |
+| `invite_not_found` | No se encontró la invitación. |
+| `invite_role_unavailable` | El rol de la invitación no está disponible. |
+| `user_already_in_organization` | El usuario ya pertenece a la organización. |
 
 ### OrganizationAccessErrorCode
 
-- `organization_admin_access_cannot_be_removed`
-- `organization_admin_assignment_cannot_be_edited`
-- `organization_admin_role_cannot_be_deleted`
-- `organization_admin_role_cannot_be_edited`
-- `organization_admin_role_required`
-- `organization_id_not_allowed`
-- `organization_id_required`
-- `owner_access_cannot_be_reassigned`
-- `owner_access_cannot_be_removed`
-- `role_has_assigned_users`
-- `role_not_found`
-- `role_template_not_found`
-- `user_access_not_found`
+| Código | Descripción |
+| --- | --- |
+| `organization_admin_access_cannot_be_removed` | No se puede remover el acceso de administrador de la organización. |
+| `organization_admin_assignment_cannot_be_edited` | No se puede editar la asignación de administrador de la organización. |
+| `organization_admin_role_cannot_be_deleted` | No se puede eliminar el rol de administrador de la organización. |
+| `organization_admin_role_cannot_be_edited` | No se puede editar el rol de administrador de la organización. |
+| `organization_admin_role_required` | Se requiere el rol de administrador de la organización. |
+| `organization_id_not_allowed` | No se permite enviar organizationId para este scope. |
+| `organization_id_required` | Se requiere organizationId para este scope. |
+| `owner_access_cannot_be_reassigned` | No se puede reasignar el acceso del propietario. |
+| `owner_access_cannot_be_removed` | No se puede remover el acceso del propietario. |
+| `role_has_assigned_users` | No se puede eliminar un rol con usuarios asignados. |
+| `role_template_not_found` | No se encontró el template del rol. |
+| `role_not_found` | No se encontró el rol. |
+| `user_access_not_found` | No se encontró el acceso del usuario. |
 
 ### OrganizationSeriesErrorCode
 
-- `series_already_exists`
-- `series_not_found`
+| Código | Descripción |
+| --- | --- |
+| `series_already_exists` | La serie ya existe. |
+| `series_not_found` | No se encontró la serie. |
 
 ### WebhookErrorCode
 
-- `webhook_delivery_attempt_not_found`
-- `webhook_not_found`
-- `webhook_signature_invalid`
+| Código | Descripción |
+| --- | --- |
+| `webhook_delivery_attempt_not_found` | No se encontró el intento de envío del webhook. |
+| `webhook_not_found` | No se encontró el webhook. |
+| `webhook_signature_invalid` | La firma del webhook no es válida. |
 
 ### ToolErrorCode
 
-- `tax_id_validation_failed`
-- `tax_id_validation_service_unavailable`
+| Código | Descripción |
+| --- | --- |
+| `tax_id_validation_failed` | No se pudo validar el RFC. |
+| `tax_id_validation_service_unavailable` | El servicio de validación de RFC no está disponible. |

--- a/website/docs/getting-started/errors.mdx
+++ b/website/docs/getting-started/errors.mdx
@@ -80,6 +80,8 @@ Si el proveedor externo devuelve detalles útiles, se incluyen en `errors[]` con
 }
 ```
 
+Para códigos de validación de timbrado emitidos por el SAT, consulta la [Matriz de errores CFDI 4.0](https://omawww.sat.gob.mx/tramitesyservicios/Paginas/documentos/MatrizDeErrores_CFDI_v40.xls) publicada dentro de la documentación oficial del [Anexo 20](https://omawww.sat.gob.mx/tramitesyservicios/Paginas/anexo_20_version3-3.htm).
+
 ## Límites de tasa
 
 Cuando alcanzas un límite, la API responde `429 Too Many Requests`, `code: "rate_limit_exceeded"` y el header `Retry-After` con los segundos recomendados antes de reintentar.

--- a/website/docs/getting-started/errors.mdx
+++ b/website/docs/getting-started/errors.mdx
@@ -84,11 +84,14 @@ Si el proveedor externo devuelve detalles útiles, se incluyen en `errors[]` con
 
 Para códigos de validación de timbrado emitidos por el SAT, consulta la [Matriz de errores CFDI 4.0](https://omawww.sat.gob.mx/tramitesyservicios/Paginas/documentos/MatrizDeErrores_CFDI_v40.xls) publicada dentro de la documentación oficial del [Anexo 20](https://omawww.sat.gob.mx/tramitesyservicios/Paginas/anexo_20_version3-3.htm).
 
-## Límites de tasa
+## Headers útiles
 
-Cuando alcanzas un límite, la API responde `429 Too Many Requests`, `code: "rate_limit_exceeded"` y el header `Retry-After` con los segundos recomendados antes de reintentar.
+Algunas respuestas de error incluyen headers útiles para manejo programático u observabilidad:
 
-También puedes conservar el header `X-Facturapi-Log-Id` en tu observabilidad para correlacionar solicitudes con soporte.
+| Header | Descripción |
+| --- | --- |
+| `Retry-After` | Segundos recomendados antes de reintentar. Se incluye en errores con `code: "rate_limit_exceeded"`. |
+| `X-Facturapi-Log-Id` | ID de correlación de la solicitud. Puedes conservarlo en tu observabilidad para investigar errores con soporte. |
 
 ## Códigos de error
 

--- a/website/docs/getting-started/rate-limits.mdx
+++ b/website/docs/getting-started/rate-limits.mdx
@@ -39,7 +39,7 @@ Cuando una solicitud excede el límite, la API responde con:
 
 - `429 Too Many Requests`
 - header `Retry-After` (segundos sugeridos antes de reintentar)
-- código de error `RATE_LIMIT_EXCEEDED`
+- código de error `rate_limit_exceeded`
 
 ### Ejemplo de manejo de `429`
 

--- a/website/i18n/en/docusaurus-plugin-content-docs/current/getting-started/errors.mdx
+++ b/website/i18n/en/docusaurus-plugin-content-docs/current/getting-started/errors.mdx
@@ -84,11 +84,14 @@ If the external provider returns useful details, they are included in `errors[]`
 
 For SAT stamping validation codes, see the [CFDI 4.0 error matrix](https://omawww.sat.gob.mx/tramitesyservicios/Paginas/documentos/MatrizDeErrores_CFDI_v40.xls) published as part of SAT's official [Anexo 20](https://omawww.sat.gob.mx/tramitesyservicios/Paginas/anexo_20_version3-3.htm) documentation.
 
-## Rate limits
+## Useful headers
 
-When you hit a limit, the API returns `429 Too Many Requests`, `code: "rate_limit_exceeded"`, and the `Retry-After` header with the recommended seconds to wait before retrying.
+Some error responses include useful headers for programmatic handling or observability:
 
-You can also preserve the `X-Facturapi-Log-Id` header in your observability stack to correlate requests with support.
+| Header | Description |
+| --- | --- |
+| `Retry-After` | Recommended seconds to wait before retrying. Included in errors with `code: "rate_limit_exceeded"`. |
+| `X-Facturapi-Log-Id` | Request correlation ID. You can keep it in your observability stack to investigate errors with support. |
 
 ## Error codes
 

--- a/website/i18n/en/docusaurus-plugin-content-docs/current/getting-started/errors.mdx
+++ b/website/i18n/en/docusaurus-plugin-content-docs/current/getting-started/errors.mdx
@@ -33,15 +33,15 @@ The API returns errors as JSON and uses standard HTTP status codes. For programm
 }
 ```
 
-| Field | Description |
-| --- | --- |
-| `message` | Human-readable error message. |
-| `status` | HTTP status code. |
-| `code` | Stable root code for handling the error. |
-| `location` | Location of the data related to the error, such as `body`, `query`, `params`, or `files`. Included only when applicable. |
-| `path` | Path of the field related to the error. Included only when applicable. |
-| `errors` | Additional details. Included only when there are multiple validation errors or relevant external details. |
-| `ok` | Always `false` for error responses. |
+| Field | Type | Description |
+| --- | --- | --- |
+| `message` | `string` | Human-readable error message. |
+| `status` | `number` | HTTP status code. |
+| `code` | `string` | Stable root code for handling the error. |
+| `location` | `string` | Location of the data related to the error, such as `body`, `query`, `params`, or `files`. Included only when applicable. |
+| `path` | `string` | Path of the field related to the error. Included only when applicable. |
+| `errors` | `array` | Additional details. Included only when there are multiple validation errors or relevant external details. |
+| `ok` | `boolean` | Always `false` for error responses. |
 
 ## Validation errors
 

--- a/website/i18n/en/docusaurus-plugin-content-docs/current/getting-started/errors.mdx
+++ b/website/i18n/en/docusaurus-plugin-content-docs/current/getting-started/errors.mdx
@@ -1,0 +1,294 @@
+---
+sidebar_position: 7
+---
+
+# Error handling
+
+:::info Availability
+The normalized error codes and messages described here apply starting June 30, 2026.
+:::
+
+The API returns errors as JSON and uses standard HTTP status codes. For programmatic error handling, use `code`: it is a stable, predictable string.
+
+`message` is meant for humans. It may change to improve clarity or support localization, so avoid using it for branching logic.
+
+## Error object
+
+```json
+{
+  "message": "La solicitud no es válida.",
+  "status": 400,
+  "code": "invalid_request",
+  "location": "body",
+  "path": "customer.email",
+  "errors": [
+    {
+      "message": "\"customer.email\" is required",
+      "code": "required",
+      "location": "body",
+      "path": "customer.email"
+    }
+  ],
+  "ok": false
+}
+```
+
+| Field | Description |
+| --- | --- |
+| `message` | Human-readable error message. |
+| `status` | HTTP status code. |
+| `code` | Stable root code for handling the error. |
+| `location` | Location of the data related to the error, such as `body`, `query`, `params`, or `files`. Included only when applicable. |
+| `path` | Path of the field related to the error. Included only when applicable. |
+| `errors` | Additional details. Included only when there are multiple validation errors or relevant external details. |
+| `ok` | Always `false` for error responses. |
+
+## Validation errors
+
+When the request does not match the input contract, the root error uses `code: "invalid_request"`. When details are available, `errors[]` includes each invalid field with `path`, `location`, and a validation subcode.
+
+Validation subcodes:
+
+- `invalid_format`
+- `invalid_length`
+- `invalid_type`
+- `not_allowed`
+- `required`
+- `too_large`
+- `too_small`
+- `unknown_field`
+
+## External errors
+
+Some operations depend on external validations or services, such as SAT or PAC. In those cases, the root `code` remains a Facturapi code, for example `invoice_stamping_validation_error`.
+
+If the external provider returns useful details, they are included in `errors[]` with the original code:
+
+```json
+{
+  "message": "La factura no pasó la validación de timbrado.",
+  "status": 400,
+  "code": "invoice_stamping_validation_error",
+  "errors": [
+    {
+      "message": "El RFC del receptor no se encuentra en la lista de RFC inscritos no cancelados del SAT.",
+      "code": "CFDI40145",
+      "source": "sat"
+    }
+  ],
+  "ok": false
+}
+```
+
+## Rate limits
+
+When you hit a limit, the API returns `429 Too Many Requests`, `code: "rate_limit_exceeded"`, and the `Retry-After` header with the recommended seconds to wait before retrying.
+
+You can also preserve the `X-Facturapi-Log-Id` header in your observability stack to correlate requests with support.
+
+## Error codes
+
+### CommonErrorCode
+
+- `conflict`
+- `forbidden`
+- `internal_error`
+- `not_found`
+- `unauthorized`
+
+### AuthErrorCode
+
+- `api_key_invalid`
+- `api_key_not_allowed`
+- `feature_not_available`
+- `live_api_key_required`
+- `mcp_permission_denied`
+- `missing_credentials`
+- `organization_incomplete`
+- `subscription_required`
+- `subscription_live_access_required`
+- `user_key_invalid`
+- `user_suspended`
+
+### RequestErrorCode
+
+- `date_range_too_large`
+- `idempotency_key_in_use`
+- `image_file_required`
+- `invalid_country_code`
+- `invalid_date`
+- `invalid_date_range`
+- `invalid_image_file`
+- `invalid_json`
+- `invalid_multipart_form_data`
+- `invalid_request`
+- `invalid_state_code`
+- `invalid_timezone`
+- `multipart_limit_exceeded`
+- `page_too_large`
+- `payload_too_large`
+- `rate_limit_exceeded`
+
+### CustomerErrorCode
+
+- `customer_could_not_be_resolved`
+- `customer_edit_link_not_found`
+- `customer_edit_link_unavailable`
+- `customer_email_required`
+- `customer_has_invoices`
+- `customer_not_found`
+- `customer_tax_info_unavailable`
+
+### ProductErrorCode
+
+- `product_not_found`
+
+### SupplierErrorCode
+
+- `supplier_not_found`
+
+### CatalogErrorCode
+
+- `product_key_not_found`
+- `tariff_code_not_found`
+- `unit_key_not_found`
+
+### InvoiceErrorCode
+
+- `invoice_already_stamped`
+- `invoice_not_draft`
+- `invoice_not_found`
+- `invoice_not_stamped`
+
+### InvoiceDraftErrorCode
+
+- `draft_not_ready_to_stamp`
+- `draft_update_in_progress`
+
+### InvoiceStampingErrorCode
+
+- `invoice_stamping_failed`
+- `invoice_stamping_service_unavailable`
+- `invoice_stamping_validation_error`
+- `manifesto_signature_failed`
+- `stamping_in_progress`
+
+### InvoiceDeliveryErrorCode
+
+- `invoice_email_delivery_failed`
+- `invoice_email_recipient_required`
+- `invoice_email_status_not_allowed`
+
+### InvoiceCancellationErrorCode
+
+- `invoice_cancellation_failed`
+- `invoice_cancellation_in_progress`
+- `invoice_cancellation_not_allowed`
+- `invoice_cancellation_not_found`
+- `invoice_cancellation_receipt_unavailable`
+- `invoice_cancellation_rfc_mismatch`
+- `invoice_cancellation_service_unavailable`
+- `invoice_not_cancelable`
+- `invoice_not_cancelable_by_sat`
+- `substitution_invoice_canceled`
+- `substitution_invoice_not_found`
+- `substitution_invoice_required`
+- `substitution_invoice_status_not_allowed`
+
+### ReceiptErrorCode
+
+- `receipt_expired`
+- `receipt_not_found`
+- `receipt_not_open`
+
+### ReceiptInvoicingErrorCode
+
+- `receipt_invoicing_customer_mismatch`
+- `receipt_invoicing_too_many_items`
+- `receipt_keys_not_found`
+
+### ReceiptGlobalInvoiceErrorCode
+
+- `global_invoice_too_many_items`
+- `invalid_global_invoice_period`
+
+### RetentionErrorCode
+
+- `invalid_retention_complement`
+- `retention_not_cancelable`
+- `retention_not_found`
+- `retention_not_stamped`
+
+### RetentionDeliveryErrorCode
+
+- `retention_email_delivery_failed`
+- `retention_email_recipient_required`
+- `retention_email_status_not_allowed`
+
+### RetentionCancellationErrorCode
+
+- `retention_cancellation_failed`
+- `retention_cancellation_service_unavailable`
+
+### RetentionStampingErrorCode
+
+- `retention_stamping_failed`
+- `retention_stamping_service_unavailable`
+- `retention_stamping_validation_error`
+
+### OrganizationErrorCode
+
+- `invalid_operation`
+- `invalid_user_id`
+- `organization_not_found`
+- `subscription_active_required`
+
+### OrganizationSettingsErrorCode
+
+- `certificate_invalid`
+- `certificate_rfc_mismatch`
+- `fiel_invalid`
+- `fiel_rfc_mismatch`
+- `organization_settings_invalid`
+- `organization_tax_info_invalid`
+
+### OrganizationInviteErrorCode
+
+- `invite_email_delivery_failed`
+- `invite_email_mismatch`
+- `invite_expired`
+- `invite_not_found`
+- `invite_role_unavailable`
+- `user_already_in_organization`
+
+### OrganizationAccessErrorCode
+
+- `organization_admin_access_cannot_be_removed`
+- `organization_admin_assignment_cannot_be_edited`
+- `organization_admin_role_cannot_be_deleted`
+- `organization_admin_role_cannot_be_edited`
+- `organization_admin_role_required`
+- `organization_id_not_allowed`
+- `organization_id_required`
+- `owner_access_cannot_be_reassigned`
+- `owner_access_cannot_be_removed`
+- `role_has_assigned_users`
+- `role_not_found`
+- `role_template_not_found`
+- `user_access_not_found`
+
+### OrganizationSeriesErrorCode
+
+- `series_already_exists`
+- `series_not_found`
+
+### WebhookErrorCode
+
+- `webhook_delivery_attempt_not_found`
+- `webhook_not_found`
+- `webhook_signature_invalid`
+
+### ToolErrorCode
+
+- `tax_id_validation_failed`
+- `tax_id_validation_service_unavailable`

--- a/website/i18n/en/docusaurus-plugin-content-docs/current/getting-started/errors.mdx
+++ b/website/i18n/en/docusaurus-plugin-content-docs/current/getting-started/errors.mdx
@@ -5,7 +5,7 @@ sidebar_position: 7
 # Error handling
 
 :::info Availability
-The normalized error codes and messages described here apply starting June 30, 2026.
+The normalized error codes and messages described here apply starting June 30, 2026. Before that date, error codes and messages may differ from what is documented on this page.
 :::
 
 The API returns errors as JSON and uses standard HTTP status codes. For programmatic error handling, use `code`: it is a stable, predictable string.
@@ -87,6 +87,8 @@ When you hit a limit, the API returns `429 Too Many Requests`, `code: "rate_limi
 You can also preserve the `X-Facturapi-Log-Id` header in your observability stack to correlate requests with support.
 
 ## Error codes
+
+This list is the documented reference for public API codes. We may add new codes at any time when new features or new error cases require them, but we aim to keep this page up to date so integrations have a predictable reference.
 
 ### CommonErrorCode
 

--- a/website/i18n/en/docusaurus-plugin-content-docs/current/getting-started/errors.mdx
+++ b/website/i18n/en/docusaurus-plugin-content-docs/current/getting-started/errors.mdx
@@ -49,14 +49,16 @@ When the request does not match the input contract, the root error uses `code: "
 
 Validation subcodes:
 
-- `invalid_format`
-- `invalid_length`
-- `invalid_type`
-- `not_allowed`
-- `required`
-- `too_large`
-- `too_small`
-- `unknown_field`
+| Code | Description |
+| --- | --- |
+| `invalid_format` | The value does not match the expected format. |
+| `invalid_length` | The value does not match the allowed length. |
+| `invalid_type` | The value has the wrong type. |
+| `not_allowed` | The value is not allowed for this field. |
+| `required` | A required field is missing. |
+| `too_large` | The value exceeds the allowed limit. |
+| `too_small` | The value is below the allowed minimum. |
+| `unknown_field` | The field is not allowed in this request. |
 
 ## External errors
 
@@ -94,205 +96,257 @@ This list is the documented reference for public API codes. We may add new codes
 
 ### CommonErrorCode
 
-- `conflict`
-- `forbidden`
-- `internal_error`
-- `not_found`
-- `unauthorized`
+| Code | Description |
+| --- | --- |
+| `conflict` | The request cannot be completed because of a conflict. |
+| `forbidden` | The authenticated caller does not have permission for this action. |
+| `internal_error` | An unexpected internal error occurred. |
+| `not_found` | The requested resource was not found. |
+| `unauthorized` | The request could not be authenticated. |
 
 ### AuthErrorCode
 
-- `api_key_invalid`
-- `api_key_not_allowed`
-- `feature_not_available`
-- `live_api_key_required`
-- `mcp_permission_denied`
-- `missing_credentials`
-- `organization_incomplete`
-- `subscription_required`
-- `subscription_live_access_required`
-- `user_key_invalid`
-- `user_suspended`
+| Code | Description |
+| --- | --- |
+| `api_key_invalid` | The provided API key is invalid. |
+| `api_key_not_allowed` | The API key cannot perform this action. |
+| `feature_not_available` | The feature is not available for the organization. |
+| `live_api_key_required` | The operation requires a live API key. |
+| `mcp_permission_denied` | The caller does not have permission to use this MCP tool. |
+| `missing_credentials` | The request did not include credentials. |
+| `organization_incomplete` | The organization is not fully configured for this operation. |
+| `subscription_required` | The operation requires an active subscription. |
+| `subscription_live_access_required` | The subscription does not allow live-mode access. |
+| `user_key_invalid` | The provided user key is invalid. |
+| `user_suspended` | The user is suspended. |
 
 ### RequestErrorCode
 
-- `date_range_too_large`
-- `idempotency_key_in_use`
-- `image_file_required`
-- `invalid_country_code`
-- `invalid_date`
-- `invalid_date_range`
-- `invalid_image_file`
-- `invalid_json`
-- `invalid_multipart_form_data`
-- `invalid_request`
-- `invalid_state_code`
-- `invalid_timezone`
-- `multipart_limit_exceeded`
-- `page_too_large`
-- `payload_too_large`
-- `rate_limit_exceeded`
+| Code | Description |
+| --- | --- |
+| `idempotency_key_in_use` | The idempotency key is already being used by another request. |
+| `rate_limit_exceeded` | The request exceeded the allowed rate limit. |
+| `date_range_too_large` | The requested date range exceeds the allowed limit. |
+| `image_file_required` | An image file is required. |
+| `invalid_country_code` | The country code is invalid. |
+| `invalid_date` | The date is invalid. |
+| `invalid_date_range` | The date range is invalid. |
+| `invalid_image_file` | The provided file is not a valid image. |
+| `invalid_json` | The request body is not valid JSON. |
+| `invalid_request` | The request is invalid. |
+| `invalid_multipart_form_data` | The multipart/form-data payload is invalid. |
+| `invalid_state_code` | The state code is invalid. |
+| `invalid_timezone` | The timezone is invalid. |
+| `multipart_limit_exceeded` | The multipart/form-data request exceeds the allowed limits. |
+| `page_too_large` | The requested page exceeds the allowed limit. |
+| `payload_too_large` | The request payload exceeds the maximum allowed size. |
 
 ### CustomerErrorCode
 
-- `customer_could_not_be_resolved`
-- `customer_edit_link_not_found`
-- `customer_edit_link_unavailable`
-- `customer_email_required`
-- `customer_has_invoices`
-- `customer_not_found`
-- `customer_tax_info_unavailable`
+| Code | Description |
+| --- | --- |
+| `customer_could_not_be_resolved` | The customer could not be resolved from the request or related resources. |
+| `customer_edit_link_not_found` | The customer edit link does not exist or has expired. |
+| `customer_edit_link_unavailable` | The customer edit link is not available. |
+| `customer_email_required` | The customer email address is required. |
+| `customer_has_invoices` | The customer cannot be deleted because it has associated invoices. |
+| `customer_not_found` | The customer was not found. |
+| `customer_tax_info_unavailable` | The customer tax information is not available. |
 
 ### ProductErrorCode
 
-- `product_not_found`
+| Code | Description |
+| --- | --- |
+| `product_not_found` | The product was not found. |
 
 ### SupplierErrorCode
 
-- `supplier_not_found`
+| Code | Description |
+| --- | --- |
+| `supplier_not_found` | The supplier was not found. |
 
 ### CatalogErrorCode
 
-- `product_key_not_found`
-- `tariff_code_not_found`
-- `unit_key_not_found`
+| Code | Description |
+| --- | --- |
+| `product_key_not_found` | The SAT product or service key was not found. |
+| `tariff_code_not_found` | The tariff fraction was not found. |
+| `unit_key_not_found` | The SAT unit key was not found. |
 
 ### InvoiceErrorCode
 
-- `invoice_already_stamped`
-- `invoice_not_draft`
-- `invoice_not_found`
-- `invoice_not_stamped`
+| Code | Description |
+| --- | --- |
+| `invoice_already_stamped` | The invoice has already been stamped. |
+| `invoice_not_draft` | The invoice is not a draft. |
+| `invoice_not_found` | The invoice was not found. |
+| `invoice_not_stamped` | The invoice has not been stamped. |
 
 ### InvoiceDraftErrorCode
 
-- `draft_not_ready_to_stamp`
-- `draft_update_in_progress`
+| Code | Description |
+| --- | --- |
+| `draft_not_ready_to_stamp` | The draft is not ready to be stamped. |
+| `draft_update_in_progress` | The draft is already being updated. |
 
 ### InvoiceStampingErrorCode
 
-- `invoice_stamping_failed`
-- `invoice_stamping_service_unavailable`
-- `invoice_stamping_validation_error`
-- `manifesto_signature_failed`
-- `stamping_in_progress`
+| Code | Description |
+| --- | --- |
+| `invoice_stamping_failed` | The invoice could not be stamped. |
+| `invoice_stamping_service_unavailable` | The stamping service is unavailable. |
+| `invoice_stamping_validation_error` | The invoice failed stamping validation. |
+| `manifesto_signature_failed` | The manifesto could not be signed. |
+| `stamping_in_progress` | Stamping for this invoice is already in progress. |
 
 ### InvoiceDeliveryErrorCode
 
-- `invoice_email_delivery_failed`
-- `invoice_email_recipient_required`
-- `invoice_email_status_not_allowed`
+| Code | Description |
+| --- | --- |
+| `invoice_email_delivery_failed` | The invoice could not be sent by email. |
+| `invoice_email_recipient_required` | No email recipient is available for the invoice. |
+| `invoice_email_status_not_allowed` | The invoice status does not allow email delivery. |
 
 ### InvoiceCancellationErrorCode
 
-- `invoice_cancellation_failed`
-- `invoice_cancellation_in_progress`
-- `invoice_cancellation_not_allowed`
-- `invoice_cancellation_not_found`
-- `invoice_cancellation_receipt_unavailable`
-- `invoice_cancellation_rfc_mismatch`
-- `invoice_cancellation_service_unavailable`
-- `invoice_not_cancelable`
-- `invoice_not_cancelable_by_sat`
-- `substitution_invoice_canceled`
-- `substitution_invoice_not_found`
-- `substitution_invoice_required`
-- `substitution_invoice_status_not_allowed`
+| Code | Description |
+| --- | --- |
+| `invoice_cancellation_in_progress` | The invoice already has a pending cancellation request. |
+| `invoice_cancellation_receipt_unavailable` | The cancellation receipt is not available. |
+| `invoice_cancellation_failed` | The invoice could not be canceled. |
+| `invoice_cancellation_not_allowed` | Invoice cancellation is not allowed. |
+| `invoice_cancellation_not_found` | The cancellation request was not found. |
+| `invoice_cancellation_rfc_mismatch` | The RFC does not match for invoice cancellation. |
+| `invoice_cancellation_service_unavailable` | The cancellation service is unavailable. |
+| `invoice_not_cancelable` | The invoice cannot be canceled. |
+| `invoice_not_cancelable_by_sat` | The invoice cannot be canceled with SAT. |
+| `substitution_invoice_canceled` | The substitution invoice is already canceled. |
+| `substitution_invoice_not_found` | The substitution invoice was not found. |
+| `substitution_invoice_required` | A substitution invoice is required. |
+| `substitution_invoice_status_not_allowed` | The substitution invoice status is not valid for this operation. |
 
 ### ReceiptErrorCode
 
-- `receipt_expired`
-- `receipt_not_found`
-- `receipt_not_open`
+| Code | Description |
+| --- | --- |
+| `receipt_expired` | The receipt has expired. |
+| `receipt_not_found` | The receipt was not found. |
+| `receipt_not_open` | The receipt is not open. |
 
 ### ReceiptInvoicingErrorCode
 
-- `receipt_invoicing_customer_mismatch`
-- `receipt_invoicing_too_many_items`
-- `receipt_keys_not_found`
+| Code | Description |
+| --- | --- |
+| `receipt_invoicing_customer_mismatch` | The receipts cannot be invoiced together for the same customer. |
+| `receipt_invoicing_too_many_items` | The receipts exceed the allowed item limit. |
+| `receipt_keys_not_found` | Not all requested receipt keys were found. |
 
 ### ReceiptGlobalInvoiceErrorCode
 
-- `global_invoice_too_many_items`
-- `invalid_global_invoice_period`
+| Code | Description |
+| --- | --- |
+| `global_invoice_too_many_items` | The global invoice exceeds the allowed item limit. |
+| `invalid_global_invoice_period` | The global invoice period is invalid. |
 
 ### RetentionErrorCode
 
-- `invalid_retention_complement`
-- `retention_not_cancelable`
-- `retention_not_found`
-- `retention_not_stamped`
+| Code | Description |
+| --- | --- |
+| `invalid_retention_complement` | The retention complement is invalid. |
+| `retention_not_found` | The retention was not found. |
+| `retention_not_stamped` | The retention has not been stamped. |
+| `retention_not_cancelable` | The retention cannot be canceled. |
 
 ### RetentionDeliveryErrorCode
 
-- `retention_email_delivery_failed`
-- `retention_email_recipient_required`
-- `retention_email_status_not_allowed`
+| Code | Description |
+| --- | --- |
+| `retention_email_delivery_failed` | The retention could not be sent by email. |
+| `retention_email_recipient_required` | No email recipient is available for the retention. |
+| `retention_email_status_not_allowed` | The retention status does not allow email delivery. |
 
 ### RetentionCancellationErrorCode
 
-- `retention_cancellation_failed`
-- `retention_cancellation_service_unavailable`
+| Code | Description |
+| --- | --- |
+| `retention_cancellation_failed` | The retention could not be canceled. |
+| `retention_cancellation_service_unavailable` | The retention cancellation service is unavailable. |
 
 ### RetentionStampingErrorCode
 
-- `retention_stamping_failed`
-- `retention_stamping_service_unavailable`
-- `retention_stamping_validation_error`
+| Code | Description |
+| --- | --- |
+| `retention_stamping_failed` | The retention could not be stamped. |
+| `retention_stamping_service_unavailable` | The retention stamping service is unavailable. |
+| `retention_stamping_validation_error` | The retention failed stamping validation. |
 
 ### OrganizationErrorCode
 
-- `invalid_operation`
-- `invalid_user_id`
-- `organization_not_found`
-- `subscription_active_required`
+| Code | Description |
+| --- | --- |
+| `invalid_operation` | The operation is invalid. |
+| `invalid_user_id` | The user is invalid. |
+| `organization_not_found` | The organization was not found. |
+| `subscription_active_required` | The organization requires an active subscription. |
 
 ### OrganizationSettingsErrorCode
 
-- `certificate_invalid`
-- `certificate_rfc_mismatch`
-- `fiel_invalid`
-- `fiel_rfc_mismatch`
-- `organization_settings_invalid`
-- `organization_tax_info_invalid`
+| Code | Description |
+| --- | --- |
+| `certificate_invalid` | The certificate is invalid. |
+| `certificate_rfc_mismatch` | The certificate RFC does not match the organization. |
+| `fiel_invalid` | The FIEL is invalid. |
+| `fiel_rfc_mismatch` | The FIEL RFC does not match the organization. |
+| `organization_settings_invalid` | The organization settings are invalid. |
+| `organization_tax_info_invalid` | The organization tax information is invalid. |
 
 ### OrganizationInviteErrorCode
 
-- `invite_email_delivery_failed`
-- `invite_email_mismatch`
-- `invite_expired`
-- `invite_not_found`
-- `invite_role_unavailable`
-- `user_already_in_organization`
+| Code | Description |
+| --- | --- |
+| `invite_email_delivery_failed` | The invitation could not be sent by email. |
+| `invite_email_mismatch` | The email address does not match the invitation. |
+| `invite_expired` | The invitation has expired. |
+| `invite_not_found` | The invitation was not found. |
+| `invite_role_unavailable` | The invitation role is not available. |
+| `user_already_in_organization` | The user already belongs to the organization. |
 
 ### OrganizationAccessErrorCode
 
-- `organization_admin_access_cannot_be_removed`
-- `organization_admin_assignment_cannot_be_edited`
-- `organization_admin_role_cannot_be_deleted`
-- `organization_admin_role_cannot_be_edited`
-- `organization_admin_role_required`
-- `organization_id_not_allowed`
-- `organization_id_required`
-- `owner_access_cannot_be_reassigned`
-- `owner_access_cannot_be_removed`
-- `role_has_assigned_users`
-- `role_not_found`
-- `role_template_not_found`
-- `user_access_not_found`
+| Code | Description |
+| --- | --- |
+| `organization_admin_access_cannot_be_removed` | Organization admin access cannot be removed. |
+| `organization_admin_assignment_cannot_be_edited` | The organization admin assignment cannot be edited. |
+| `organization_admin_role_cannot_be_deleted` | The organization admin role cannot be deleted. |
+| `organization_admin_role_cannot_be_edited` | The organization admin role cannot be edited. |
+| `organization_admin_role_required` | The organization admin role is required. |
+| `organization_id_not_allowed` | organizationId is not allowed for this scope. |
+| `organization_id_required` | organizationId is required for this scope. |
+| `owner_access_cannot_be_reassigned` | Owner access cannot be reassigned. |
+| `owner_access_cannot_be_removed` | Owner access cannot be removed. |
+| `role_has_assigned_users` | The role cannot be deleted because it has assigned users. |
+| `role_template_not_found` | The role template was not found. |
+| `role_not_found` | The role was not found. |
+| `user_access_not_found` | The user access assignment was not found. |
 
 ### OrganizationSeriesErrorCode
 
-- `series_already_exists`
-- `series_not_found`
+| Code | Description |
+| --- | --- |
+| `series_already_exists` | The series already exists. |
+| `series_not_found` | The series was not found. |
 
 ### WebhookErrorCode
 
-- `webhook_delivery_attempt_not_found`
-- `webhook_not_found`
-- `webhook_signature_invalid`
+| Code | Description |
+| --- | --- |
+| `webhook_delivery_attempt_not_found` | The webhook delivery attempt was not found. |
+| `webhook_not_found` | The webhook was not found. |
+| `webhook_signature_invalid` | The webhook signature is invalid. |
 
 ### ToolErrorCode
 
-- `tax_id_validation_failed`
-- `tax_id_validation_service_unavailable`
+| Code | Description |
+| --- | --- |
+| `tax_id_validation_failed` | The RFC could not be validated. |
+| `tax_id_validation_service_unavailable` | The RFC validation service is unavailable. |

--- a/website/i18n/en/docusaurus-plugin-content-docs/current/getting-started/errors.mdx
+++ b/website/i18n/en/docusaurus-plugin-content-docs/current/getting-started/errors.mdx
@@ -80,6 +80,8 @@ If the external provider returns useful details, they are included in `errors[]`
 }
 ```
 
+For SAT stamping validation codes, see the [CFDI 4.0 error matrix](https://omawww.sat.gob.mx/tramitesyservicios/Paginas/documentos/MatrizDeErrores_CFDI_v40.xls) published as part of SAT's official [Anexo 20](https://omawww.sat.gob.mx/tramitesyservicios/Paginas/anexo_20_version3-3.htm) documentation.
+
 ## Rate limits
 
 When you hit a limit, the API returns `429 Too Many Requests`, `code: "rate_limit_exceeded"`, and the `Retry-After` header with the recommended seconds to wait before retrying.

--- a/website/i18n/en/docusaurus-plugin-content-docs/current/getting-started/rate-limits.mdx
+++ b/website/i18n/en/docusaurus-plugin-content-docs/current/getting-started/rate-limits.mdx
@@ -39,7 +39,7 @@ When a request exceeds the limit, the API returns:
 
 - `429 Too Many Requests`
 - `Retry-After` header (recommended seconds before retrying)
-- `RATE_LIMIT_EXCEEDED` error code
+- `rate_limit_exceeded` error code
 
 ### Example `429` handling
 

--- a/website/openapi_v2.en.yaml
+++ b/website/openapi_v2.en.yaml
@@ -10976,7 +10976,7 @@ components:
             message: Too many requests. Please retry shortly.
             status: 429
             ok: false
-            code: RATE_LIMIT_EXCEEDED
+            code: rate_limit_exceeded
     UnexpectedError:
       description: Unexpected error
       content:
@@ -11282,13 +11282,51 @@ components:
           description: Indicates if the request was successful. Always `false` for error responses.
           example: false
         code:
-          description: Optional error code (for example, RATE_LIMIT_EXCEEDED).
-          oneOf:
-            - type: string
-            - type: integer
+          type: string
+          description: Stable error code for programmatic handling. See the error handling guide for the documented code list.
+          example: invalid_request
+        location:
+          type: string
+          description: Optional location of the data related to the error.
+          enum:
+            - body
+            - query
+            - params
+            - headers
+            - files
         path:
           type: string
           description: Optional path to the field related to the error.
+        errors:
+          type: array
+          description: Additional error details. Included only when there are validation errors or relevant external details.
+          items:
+            $ref: "#/components/schemas/ErrorDetail"
+    ErrorDetail:
+      type: object
+      properties:
+        message:
+          type: string
+          description: Human-readable detail message.
+        code:
+          type: string
+          description: Detail subcode. Validation errors use codes such as `required` or `invalid_type`; external errors may contain the provider's original code.
+          example: required
+        location:
+          type: string
+          description: Optional location of the data related to this detail.
+          enum:
+            - body
+            - query
+            - params
+            - headers
+            - files
+        path:
+          type: string
+          description: Optional path to the field related to this detail.
+        source:
+          type: string
+          description: Optional source for external details, for example `sat`.
     IssuingType:
       type: string
       description: Indicates whether the invoice was issued by your organization or received from a third party.

--- a/website/openapi_v2.yaml
+++ b/website/openapi_v2.yaml
@@ -11180,7 +11180,7 @@ components:
             message: Too many requests. Please retry shortly.
             status: 429
             ok: false
-            code: RATE_LIMIT_EXCEEDED
+            code: rate_limit_exceeded
     UnexpectedError:
       description: Error inesperado
       content:
@@ -11516,13 +11516,51 @@ components:
           description: Indica si la petición fue exitosa. Siempre `false` en respuestas de error.
           example: false
         code:
-          description: Código de error opcional (por ejemplo, RATE_LIMIT_EXCEEDED).
-          oneOf:
-            - type: string
-            - type: integer
+          type: string
+          description: Código de error estable para manejar el error de forma programática. Consulta la guía de manejo de errores para ver la lista de códigos documentados.
+          example: invalid_request
+        location:
+          type: string
+          description: Ubicación opcional del dato relacionado con el error.
+          enum:
+            - body
+            - query
+            - params
+            - headers
+            - files
         path:
           type: string
           description: Ruta opcional del campo relacionado con el error.
+        errors:
+          type: array
+          description: Detalles adicionales del error. Sólo se incluye cuando hay errores de validación o detalles externos relevantes.
+          items:
+            $ref: "#/components/schemas/ErrorDetail"
+    ErrorDetail:
+      type: object
+      properties:
+        message:
+          type: string
+          description: Mensaje legible del detalle.
+        code:
+          type: string
+          description: Subcódigo del detalle. En validaciones usa códigos como `required` o `invalid_type`; en errores externos puede contener el código original del proveedor.
+          example: required
+        location:
+          type: string
+          description: Ubicación opcional del dato relacionado con este detalle.
+          enum:
+            - body
+            - query
+            - params
+            - headers
+            - files
+        path:
+          type: string
+          description: Ruta opcional del campo relacionado con este detalle.
+        source:
+          type: string
+          description: Fuente opcional para detalles externos, por ejemplo `sat`.
     IssuingType:
       type: string
       description: Indica si la factura fue emitida por tu organización o recibida de un tercero.


### PR DESCRIPTION
## Objetivo

Documentar el nuevo contrato de errores de la API antes de publicar la normalización de códigos el 30 de junio de 2026.

## Cambios

- Agrega una guía de manejo de errores en español e inglés.
- Documenta `code` como string estable para manejo programático.
- Documenta `location`, `path` y `errors[]` como campos condicionales para validaciones y detalles externos.
- Lista los códigos públicos por categoría (`CommonErrorCode`, `AuthErrorCode`, `RequestErrorCode`, `InvoiceErrorCode`, `ReceiptInvoicingErrorCode`, etc.).
- Actualiza OpenAPI para reflejar el shape del objeto de error y `ErrorDetail`.
- Actualiza rate limits para usar `rate_limit_exceeded`.

## Validación

- `yarn --cwd website build`
- `ruby -ryaml -e 'ARGV.each { |f| YAML.load_file(f); puts "OK #{f}" }' website/openapi_v2.yaml website/openapi_v2.en.yaml`\n- `git diff --check`