### PR TITLE
docs: aclarar subcódigos de error

### DIFF
--- a/website/docs/getting-started/errors.mdx
+++ b/website/docs/getting-started/errors.mdx
@@ -16,6 +16,7 @@ La API responde los errores en JSON y usa códigos de estado HTTP estándar. Par
 
 ```json
 {
+  "ok": false,
   "message": "La solicitud no es válida.",
   "status": 400,
   "code": "invalid_request",
@@ -28,39 +29,38 @@ La API responde los errores en JSON y usa códigos de estado HTTP estándar. Par
       "location": "body",
       "path": "customer.email"
     }
-  ],
-  "ok": false
+  ]
 }
 ```
 
 | Campo | Tipo | Descripción |
 | --- | --- | --- |
+| `ok` | `boolean` | Siempre es `false` en respuestas de error. Puedes ignorarlo para manejo programático. |
 | `message` | `string` | Mensaje legible para humanos. |
 | `status` | `number` | Código de estado HTTP. |
 | `code` | `string` | Código raíz estable para manejar el error. |
 | `location` | `string` | Ubicación del dato relacionado con el error, por ejemplo `body`, `query`, `params` o `files`. Sólo se incluye cuando aplica. |
 | `path` | `string` | Ruta del campo relacionado con el error. Sólo se incluye cuando aplica. |
 | `errors` | `array` | Detalles adicionales. Sólo se incluye cuando hay múltiples errores de validación o detalles externos relevantes. |
-| `ok` | `boolean` | Siempre es `false` en respuestas de error. |
+| `errors[].message` | `string` | Mensaje legible de un detalle. |
+| `errors[].code` | `string` | Subcódigo del detalle. En errores de validación usa un `ValidationErrorCode`; en errores externos puede ser el código original del SAT o PAC. |
+| `errors[].location` | `string` | Ubicación del dato relacionado con el detalle, por ejemplo `body`, `query`, `params` o `files`. |
+| `errors[].path` | `string` | Ruta del campo relacionado con el detalle. |
+| `errors[].source` | `string` | Fuente externa del detalle, por ejemplo `sat` o `pac`. Sólo se incluye para errores externos. |
 
-## Errores de validación
+## Cómo interpretar los códigos
+
+El `code` raíz clasifica el resultado principal de la solicitud y es el valor que deberías usar primero para decidir cómo manejar el error.
+
+Los códigos dentro de `errors[]` son subcódigos de detalle. Sirven para explicar campos inválidos o respuestas externas, pero no reemplazan al `code` raíz. Pueden ser subcódigos de validación definidos por Facturapi o códigos originales de sistemas externos como SAT o PAC.
+
+### Errores de validación
 
 Cuando la petición no cumple el contrato de entrada, el error raíz usa `code: "invalid_request"`. Si hay detalles, `errors[]` incluye cada campo inválido con `path`, `location` y un subcódigo de validación.
 
-Subcódigos de validación:
+Los subcódigos de validación están documentados al final de esta página como subcódigos de detalle porque aparecen en `errors[].code`, no en `error.code`.
 
-| Código | Descripción |
-| --- | --- |
-| `invalid_format` | El valor no cumple el formato esperado. |
-| `invalid_length` | El valor no cumple la longitud permitida. |
-| `invalid_type` | El valor no tiene el tipo esperado. |
-| `not_allowed` | El valor no está permitido para este campo. |
-| `required` | Falta un campo requerido. |
-| `too_large` | El valor excede el límite permitido. |
-| `too_small` | El valor está por debajo del mínimo permitido. |
-| `unknown_field` | El campo no está permitido en esta petición. |
-
-## Errores externos
+### Errores externos
 
 Algunas operaciones dependen de validaciones o servicios externos, como SAT o PAC. En esos casos, el `code` raíz sigue siendo un código de Facturapi, por ejemplo `invoice_stamping_validation_error`.
 
@@ -93,9 +93,9 @@ Algunas respuestas de error incluyen headers útiles para manejo programático u
 | `Retry-After` | Segundos recomendados antes de reintentar. Se incluye en errores con `code: "rate_limit_exceeded"`. |
 | `X-Facturapi-Log-Id` | ID de correlación de la solicitud. Puedes conservarlo en tu observabilidad para investigar errores con soporte. |
 
-## Códigos de error
+## Códigos raíz (`error.code`)
 
-Esta lista es la referencia documentada de códigos públicos de la API. Podemos agregar nuevos códigos en cualquier momento cuando nuevas funcionalidades o nuevos casos de error lo requieran, pero procuramos mantener esta página actualizada para que las integraciones tengan una referencia predecible.
+Esta lista es la referencia documentada de códigos raíz públicos de la API. Podemos agregar nuevos códigos en cualquier momento cuando nuevas funcionalidades o nuevos casos de error lo requieran, pero procuramos mantener esta página actualizada para que las integraciones tengan una referencia predecible.
 
 ### CommonErrorCode
 
@@ -353,3 +353,28 @@ Esta lista es la referencia documentada de códigos públicos de la API. Podemos
 | --- | --- |
 | `tax_id_validation_failed` | No se pudo validar el RFC. |
 | `tax_id_validation_service_unavailable` | El servicio de validación de RFC no está disponible. |
+
+## Subcódigos de detalle (`errors[].code`)
+
+Estos valores aparecen dentro de `errors[]` para explicar detalles específicos del error raíz. No son códigos raíz.
+
+### Validación de entrada
+
+Estos subcódigos pueden aparecer cuando el código raíz es `invalid_request`.
+
+| Código | Descripción |
+| --- | --- |
+| `invalid_format` | El valor no cumple el formato esperado. |
+| `invalid_length` | El valor no cumple la longitud permitida. |
+| `invalid_type` | El valor no tiene el tipo esperado. |
+| `not_allowed` | El valor no está permitido para este campo. |
+| `required` | Falta un campo requerido. |
+| `too_large` | El valor excede el límite permitido. |
+| `too_small` | El valor está por debajo del mínimo permitido. |
+| `unknown_field` | El campo no está permitido en esta petición. |
+
+### Códigos externos
+
+Cuando un sistema externo devuelve un código útil, Facturapi lo conserva en `errors[].code` y agrega `errors[].source` para indicar cómo interpretarlo. Por ejemplo, en errores de timbrado, `source: "sat"` indica que `errors[].code` corresponde a un código de validación del SAT, como `CFDI40145`.
+
+Los códigos externos no se enumeran aquí porque pertenecen al sistema que los emite. Para códigos de validación de timbrado emitidos por el SAT, consulta la [Matriz de errores CFDI 4.0](https://omawww.sat.gob.mx/tramitesyservicios/Paginas/documentos/MatrizDeErrores_CFDI_v40.xls).

--- a/website/i18n/en/docusaurus-plugin-content-docs/current/getting-started/errors.mdx
+++ b/website/i18n/en/docusaurus-plugin-content-docs/current/getting-started/errors.mdx
@@ -16,6 +16,7 @@ The API returns errors as JSON and uses standard HTTP status codes. For programm
 
 ```json
 {
+  "ok": false,
   "message": "La solicitud no es válida.",
   "status": 400,
   "code": "invalid_request",
@@ -28,39 +29,38 @@ The API returns errors as JSON and uses standard HTTP status codes. For programm
       "location": "body",
       "path": "customer.email"
     }
-  ],
-  "ok": false
+  ]
 }
 ```
 
 | Field | Type | Description |
 | --- | --- | --- |
+| `ok` | `boolean` | Always `false` for error responses. You can ignore it for programmatic handling. |
 | `message` | `string` | Human-readable error message. |
 | `status` | `number` | HTTP status code. |
 | `code` | `string` | Stable root code for handling the error. |
 | `location` | `string` | Location of the data related to the error, such as `body`, `query`, `params`, or `files`. Included only when applicable. |
 | `path` | `string` | Path of the field related to the error. Included only when applicable. |
 | `errors` | `array` | Additional details. Included only when there are multiple validation errors or relevant external details. |
-| `ok` | `boolean` | Always `false` for error responses. |
+| `errors[].message` | `string` | Human-readable message for a detail. |
+| `errors[].code` | `string` | Detail subcode. For validation errors, this uses a `ValidationErrorCode`; for external errors, it may be the original SAT or PAC code. |
+| `errors[].location` | `string` | Location of the data related to the detail, such as `body`, `query`, `params`, or `files`. |
+| `errors[].path` | `string` | Path of the field related to the detail. |
+| `errors[].source` | `string` | External source for the detail, such as `sat` or `pac`. Included only for external errors. |
 
-## Validation errors
+## Interpreting codes
+
+The root `code` classifies the main result of the request and is the value you should check first when deciding how to handle an error.
+
+Codes inside `errors[]` are detail subcodes. They explain invalid fields or external responses, but they do not replace the root `code`. They may be Facturapi validation subcodes or original codes from external systems such as SAT or PAC.
+
+### Validation errors
 
 When the request does not match the input contract, the root error uses `code: "invalid_request"`. When details are available, `errors[]` includes each invalid field with `path`, `location`, and a validation subcode.
 
-Validation subcodes:
+Validation subcodes are documented at the end of this page as detail subcodes because they appear in `errors[].code`, not in `error.code`.
 
-| Code | Description |
-| --- | --- |
-| `invalid_format` | The value does not match the expected format. |
-| `invalid_length` | The value does not match the allowed length. |
-| `invalid_type` | The value has the wrong type. |
-| `not_allowed` | The value is not allowed for this field. |
-| `required` | A required field is missing. |
-| `too_large` | The value exceeds the allowed limit. |
-| `too_small` | The value is below the allowed minimum. |
-| `unknown_field` | The field is not allowed in this request. |
-
-## External errors
+### External errors
 
 Some operations depend on external validations or services, such as SAT or PAC. In those cases, the root `code` remains a Facturapi code, for example `invoice_stamping_validation_error`.
 
@@ -93,9 +93,9 @@ Some error responses include useful headers for programmatic handling or observa
 | `Retry-After` | Recommended seconds to wait before retrying. Included in errors with `code: "rate_limit_exceeded"`. |
 | `X-Facturapi-Log-Id` | Request correlation ID. You can keep it in your observability stack to investigate errors with support. |
 
-## Error codes
+## Root error codes (`error.code`)
 
-This list is the documented reference for public API codes. We may add new codes at any time when new features or new error cases require them, but we aim to keep this page up to date so integrations have a predictable reference.
+This list is the documented reference for public root API codes. We may add new codes at any time when new features or new error cases require them, but we aim to keep this page up to date so integrations have a predictable reference.
 
 ### CommonErrorCode
 
@@ -353,3 +353,28 @@ This list is the documented reference for public API codes. We may add new codes
 | --- | --- |
 | `tax_id_validation_failed` | The RFC could not be validated. |
 | `tax_id_validation_service_unavailable` | The RFC validation service is unavailable. |
+
+## Detail subcodes (`errors[].code`)
+
+These values appear inside `errors[]` to explain specific details of the root error. They are not root error codes.
+
+### Input validation
+
+These subcodes may appear when the root code is `invalid_request`.
+
+| Code | Description |
+| --- | --- |
+| `invalid_format` | The value does not match the expected format. |
+| `invalid_length` | The value does not match the allowed length. |
+| `invalid_type` | The value has the wrong type. |
+| `not_allowed` | The value is not allowed for this field. |
+| `required` | A required field is missing. |
+| `too_large` | The value exceeds the allowed limit. |
+| `too_small` | The value is below the allowed minimum. |
+| `unknown_field` | The field is not allowed in this request. |
+
+### External codes
+
+When an external system returns a useful code, Facturapi preserves it in `errors[].code` and adds `errors[].source` to indicate how to interpret it. For example, in stamping errors, `source: "sat"` means `errors[].code` is a SAT validation code, such as `CFDI40145`.
+
+External codes are not enumerated here because they belong to the system that emits them. For SAT stamping validation codes, see the [CFDI 4.0 error matrix](https://omawww.sat.gob.mx/tramitesyservicios/Paginas/documentos/MatrizDeErrores_CFDI_v40.xls).


### PR DESCRIPTION
## Qué cambia

- Reordena la sección del objeto de error para mostrar `ok` primero y marcarlo como campo descartable para manejo programático.
- Documenta los campos de `errors[]` dentro de la misma tabla del objeto de error.
- Aclara la diferencia entre códigos raíz (`error.code`) y subcódigos de detalle (`errors[].code`).
- Separa los subcódigos de detalle entre validaciones de entrada y códigos externos como SAT/PAC.

## Validación

- `yarn --cwd website build`
