### PR TITLE
docs: corregir deploy con pnpm

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -3,7 +3,9 @@ name: Deploy to GitHub Pages
 on:
   push:
     branches: [main]
-    paths: [website/**]
+    paths:
+      - website/**
+      - .github/workflows/documentation.yml
 
 jobs:
   deploy:
@@ -12,14 +14,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 11.5.1
+
       - uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version: 24.x
           cache: pnpm
           cache-dependency-path: website/pnpm-lock.yaml
-
-      - name: Enable Corepack
-        run: corepack enable
 
       - name: Build website
         working-directory: website


### PR DESCRIPTION
## Objetivo

Corregir el deploy de documentación después de migrar a pnpm.

## Qué cambia

- Instala pnpm explícitamente con `pnpm/action-setup@v4` antes de `actions/setup-node`.
- Sube el workflow a Node `24.x` para evitar la deprecación de Node 20 en GitHub Actions.
- Mantiene el cache de pnpm en `actions/setup-node@v4` ahora que el ejecutable ya existe.
- Incluye `.github/workflows/documentation.yml` en `paths` para que este fix dispare deploy al mergearse.

## Validación

- `pnpm --dir website install --frozen-lockfile`
- `pnpm --dir website typecheck`
- `pnpm --dir website build`
