### PR TITLE
[codex] Document egress payment method

### DIFF
--- a/website/openapi_v2.en.yaml
+++ b/website/openapi_v2.en.yaml
@@ -15305,6 +15305,14 @@ components:
               maxLength: 2
               example: "03"
               description: Payment form code according to the [Payment Form catalog](#forma-de-pago).
+            payment_method:
+              type: string
+              default: PUE
+              enum:
+                - PUE
+              description: |
+                Payment method code according to the SAT catalog. For Egress invoices,
+                this field is optional and the only allowed value is `PUE` (Payment in One Installment).
             related_documents:
               type: array
               description: |
@@ -15613,6 +15621,13 @@ components:
               maxLength: 2
               example: "03"
               description: Payment form code according to the [Payment Form catalog](#forma-de-pago).
+            payment_method:
+              type: string
+              enum:
+                - PUE
+              description: |
+                Payment method code according to the SAT catalog. For Egress invoices,
+                this field is optional and the only allowed value is `PUE` (Payment in One Installment).
             related_documents:
               type: array
               description: |

--- a/website/openapi_v2.yaml
+++ b/website/openapi_v2.yaml
@@ -15579,6 +15579,14 @@ components:
               maxLength: 2
               example: "03"
               description: Código que representa la forma de pago, de acuerdo al [catálogo del SAT](#forma-de-pago).
+            payment_method:
+              type: string
+              default: PUE
+              enum:
+                - PUE
+              description: |
+                Código del método de pago según el catálogo del SAT. Para facturas de Egreso,
+                este campo es opcional y el único valor permitido es `PUE` (Pago en Una sola Exhibición).
             related_documents:
               type: array
               description: Documentos relacionados con la nota de crédito.
@@ -15884,6 +15892,13 @@ components:
               maxLength: 2
               example: "03"
               description: Código que representa la forma de pago, de acuerdo al [catálogo del SAT](#forma-de-pago).
+            payment_method:
+              type: string
+              enum:
+                - PUE
+              description: |
+                Código del método de pago según el catálogo del SAT. Para facturas de Egreso,
+                este campo es opcional y el único valor permitido es `PUE` (Pago en Una sola Exhibición).
             related_documents:
               type: array
               description: Documentos relacionados con la nota de crédito.


### PR DESCRIPTION
## Summary
- Document `payment_method` on Egress invoice create and edit schemas in the Spanish OpenAPI v2 spec.
- Mirror the same optional `PUE`-only field in the English OpenAPI v2 spec.

## Validation
- `ruby -e "require 'yaml'; %w[website/openapi_v2.yaml website/openapi_v2.en.yaml].each { |f| YAML.load_file(f); puts \"#{f} ok\" }"`\n- `git diff --check`\n\n## Notes\n- `pnpm --dir website typecheck` currently fails before this change on `src/theme/Navbar/Logo/index.tsx` because TypeScript cannot resolve `@docusaurus/theme-common`.\n