### PR TITLE
[codex] Clarify invoice list defaults

### DIFF
--- a/website/openapi_v2.en.yaml
+++ b/website/openapi_v2.en.yaml
@@ -1049,6 +1049,7 @@ paths:
           schema:
             type: integer
             minimum: 0
+            maximum: 30
           required: false
         - in: query
           name: limit
@@ -1149,6 +1150,7 @@ paths:
           schema:
             type: integer
             minimum: 0
+            maximum: 30
         - in: query
           name: limit
           schema:
@@ -1231,6 +1233,7 @@ paths:
           schema:
             type: integer
             minimum: 0
+            maximum: 30
           required: false
         - in: query
           name: limit
@@ -1325,6 +1328,7 @@ paths:
           schema:
             type: integer
             minimum: 0
+            maximum: 30
         - in: query
           name: limit
           schema:
@@ -1407,6 +1411,7 @@ paths:
           schema:
             type: integer
             minimum: 0
+            maximum: 30
         - in: query
           name: limit
           schema:
@@ -1489,6 +1494,7 @@ paths:
           schema:
             type: integer
             minimum: 0
+            maximum: 30
         - in: query
           name: limit
           schema:
@@ -1571,6 +1577,7 @@ paths:
           schema:
             type: integer
             minimum: 0
+            maximum: 30
         - in: query
           name: limit
           schema:
@@ -1653,6 +1660,7 @@ paths:
           schema:
             type: integer
             minimum: 0
+            maximum: 30
         - in: query
           name: limit
           schema:
@@ -1735,6 +1743,7 @@ paths:
           schema:
             type: integer
             minimum: 0
+            maximum: 30
         - in: query
           name: limit
           schema:
@@ -1831,6 +1840,7 @@ paths:
           schema:
             type: integer
             minimum: 0
+            maximum: 30
         - in: query
           name: limit
           schema:
@@ -1913,6 +1923,7 @@ paths:
           schema:
             type: integer
             minimum: 0
+            maximum: 30
         - in: query
           name: limit
           schema:
@@ -11232,7 +11243,8 @@ components:
       schema:
         type: integer
         minimum: 1
-      description: Page of results to return, starting from page 1.
+        maximum: 30
+      description: Page of results to return, starting from page 1. The maximum page that can be requested is 30.
     SearchLimit:
       in: query
       name: limit

--- a/website/openapi_v2.en.yaml
+++ b/website/openapi_v2.en.yaml
@@ -3187,6 +3187,8 @@ paths:
       summary: List invoices
       description: |
         Returns a paginated list of all invoices in an organization or performs a search according to parameters.
+
+        By default, results are ordered by issue date, using the `date` field in descending order.
       x-codeSamples:
         - lang: Bash
           label: cURL
@@ -3370,7 +3372,9 @@ paths:
         - in: query
           name: issuer_type
           schema:
-            $ref: '#/components/schemas/IssuingType'
+            allOf:
+              - $ref: '#/components/schemas/IssuingType'
+            default: issuing
           description: Filter by issuing type.
         - in: query
           name: cancellation_status
@@ -3393,9 +3397,27 @@ paths:
               - paid
               - unpaid
           description: Filter by payment status. Exact match.
-        - $ref: "#/components/parameters/SearchDate"
-        - $ref: "#/components/parameters/SearchPage"
-        - $ref: "#/components/parameters/SearchLimit"
+        - in: query
+          name: date
+          style: deepObject
+          schema:
+            $ref: "#/components/schemas/DateRange"
+          description: Object with requested date range. The range filters the invoice `date` field.
+        - in: query
+          name: page
+          schema:
+            type: integer
+            minimum: 1
+            default: 1
+          description: Page of results to return, starting from page 1.
+        - in: query
+          name: limit
+          schema:
+            type: integer
+            minimum: 1
+            default: 100
+            maximum: 100
+          description: Number from 1 to 100 representing the maximum amount of results to return for pagination purposes.
       security:
         - "SecretLiveKey": []
         - "SecretTestKey": []

--- a/website/openapi_v2.en.yaml
+++ b/website/openapi_v2.en.yaml
@@ -3408,8 +3408,9 @@ paths:
           schema:
             type: integer
             minimum: 1
+            maximum: 30
             default: 1
-          description: Page of results to return, starting from page 1.
+          description: Page of results to return, starting from page 1. The maximum page that can be requested is 30.
         - in: query
           name: limit
           schema:
@@ -11231,7 +11232,8 @@ components:
       schema:
         type: integer
         minimum: 1
-      description: Page of results to return, starting from page 1.
+        maximum: 30
+      description: Page of results to return, starting from page 1. The maximum page that can be requested is 30.
     SearchLimit:
       in: query
       name: limit

--- a/website/openapi_v2.en.yaml
+++ b/website/openapi_v2.en.yaml
@@ -11232,8 +11232,7 @@ components:
       schema:
         type: integer
         minimum: 1
-        maximum: 30
-      description: Page of results to return, starting from page 1. The maximum page that can be requested is 30.
+      description: Page of results to return, starting from page 1.
     SearchLimit:
       in: query
       name: limit

--- a/website/openapi_v2.yaml
+++ b/website/openapi_v2.yaml
@@ -3634,8 +3634,9 @@ paths:
           schema:
             type: integer
             minimum: 1
+            maximum: 30
             default: 1
-          description: Página de resultados a regresar, empezando desde la página 1.
+          description: Página de resultados a regresar, empezando desde la página 1. La página máxima que se puede solicitar es 30.
         - in: query
           name: limit
           schema:
@@ -11437,7 +11438,8 @@ components:
       schema:
         type: integer
         minimum: 1
-      description: Página de resultados a regresar, empezando desde la página 1.
+        maximum: 30
+      description: Página de resultados a regresar, empezando desde la página 1. La página máxima que se puede solicitar es 30.
     SearchLimit:
       in: query
       name: limit

--- a/website/openapi_v2.yaml
+++ b/website/openapi_v2.yaml
@@ -3411,7 +3411,10 @@ paths:
       tags:
         - invoice
       summary: Listar facturas
-      description: Regresa una lista paginada de todas las facturas de una organización o realiza una búsqueda de acuerdo a parámetros
+      description: |
+        Regresa una lista paginada de todas las facturas de una organización o realiza una búsqueda de acuerdo a parámetros.
+
+        Por defecto, los resultados se ordenan por fecha de emisión, usando el campo `date` de forma descendente.
       x-codeSamples:
         - lang: Bash
           label: cURL
@@ -3595,7 +3598,9 @@ paths:
         - in: query
           name: issuer_type
           schema:
-            $ref: '#/components/schemas/IssuingType'
+            allOf:
+              - $ref: '#/components/schemas/IssuingType'
+            default: issuing
           description: Filtrar por tipo de emisión.
         - in: query
           name: cancellation_status
@@ -3618,9 +3623,27 @@ paths:
               - paid
               - unpaid
           description: Filtrar por estado de pago. Coincidencia exacta.
-        - $ref: "#/components/parameters/SearchDate"
-        - $ref: "#/components/parameters/SearchPage"
-        - $ref: "#/components/parameters/SearchLimit"
+        - in: query
+          name: date
+          style: deepObject
+          schema:
+            $ref: "#/components/schemas/DateRange"
+          description: Objeto con rango de fechas solicitado. El rango filtra el campo `date` de la factura.
+        - in: query
+          name: page
+          schema:
+            type: integer
+            minimum: 1
+            default: 1
+          description: Página de resultados a regresar, empezando desde la página 1.
+        - in: query
+          name: limit
+          schema:
+            type: integer
+            minimum: 1
+            default: 100
+            maximum: 100
+          description: Número del 1 al 100 que representa la cantidad máxima de resultados a regresar con motivos de paginación.
       security:
         - "SecretLiveKey": []
         - "SecretTestKey": []

--- a/website/openapi_v2.yaml
+++ b/website/openapi_v2.yaml
@@ -1020,6 +1020,7 @@ paths:
           schema:
             type: integer
             minimum: 0
+            maximum: 30
         - in: query
           name: limit
           schema:
@@ -1128,6 +1129,7 @@ paths:
           schema:
             type: integer
             minimum: 0
+            maximum: 30
         - in: query
           name: limit
           schema:
@@ -1236,6 +1238,7 @@ paths:
           schema:
             type: integer
             minimum: 0
+            maximum: 30
         - in: query
           name: limit
           schema:
@@ -1344,6 +1347,7 @@ paths:
           schema:
             type: integer
             minimum: 0
+            maximum: 30
         - in: query
           name: limit
           schema:
@@ -1452,6 +1456,7 @@ paths:
           schema:
             type: integer
             minimum: 0
+            maximum: 30
         - in: query
           name: limit
           schema:
@@ -1560,6 +1565,7 @@ paths:
           schema:
             type: integer
             minimum: 0
+            maximum: 30
         - in: query
           name: limit
           schema:
@@ -1668,6 +1674,7 @@ paths:
           schema:
             type: integer
             minimum: 0
+            maximum: 30
         - in: query
           name: limit
           schema:
@@ -1776,6 +1783,7 @@ paths:
           schema:
             type: integer
             minimum: 0
+            maximum: 30
         - in: query
           name: limit
           schema:
@@ -1884,6 +1892,7 @@ paths:
           schema:
             type: integer
             minimum: 0
+            maximum: 30
         - in: query
           name: limit
           schema:
@@ -2006,6 +2015,7 @@ paths:
           schema:
             type: integer
             minimum: 0
+            maximum: 30
         - in: query
           name: limit
           schema:
@@ -2114,6 +2124,7 @@ paths:
           schema:
             type: integer
             minimum: 0
+            maximum: 30
         - in: query
           name: limit
           schema:
@@ -11438,7 +11449,8 @@ components:
       schema:
         type: integer
         minimum: 1
-      description: Página de resultados a regresar, empezando desde la página 1.
+        maximum: 30
+      description: Página de resultados a regresar, empezando desde la página 1. La página máxima que se puede solicitar es 30.
     SearchLimit:
       in: query
       name: limit

--- a/website/openapi_v2.yaml
+++ b/website/openapi_v2.yaml
@@ -11438,8 +11438,7 @@ components:
       schema:
         type: integer
         minimum: 1
-        maximum: 30
-      description: Página de resultados a regresar, empezando desde la página 1. La página máxima que se puede solicitar es 30.
+      description: Página de resultados a regresar, empezando desde la página 1.
     SearchLimit:
       in: query
       name: limit


### PR DESCRIPTION
## Summary
- Document effective defaults for `GET /invoices`: `issuer_type=issuing`, `page=1`, and `limit=100`.
- Clarify that invoice list results are ordered by the invoice `date` field by default.
- Clarify that the `date` range filter applies to the invoice `date` field.

## Validation
- `ruby -e "require 'yaml'; %w[website/openapi_v2.yaml website/openapi_v2.en.yaml].each { |f| YAML.load_file(f); puts \"#{f} ok\" }"`\n- `pnpm --dir website typecheck`\n- `git diff --check`\n