### PR TITLE
Actualiza documentación pública de errores API

### DIFF
--- a/website/docs/getting-started/errors.mdx
+++ b/website/docs/getting-started/errors.mdx
@@ -63,18 +63,18 @@ Los subcódigos de validación están documentados al final de esta página como
 
 Algunas operaciones dependen de validaciones o servicios externos, como SAT o PAC. En esos casos, el `code` raíz sigue siendo un código de Facturapi, por ejemplo `invoice_stamping_validation_error`.
 
-Si el proveedor externo devuelve detalles útiles, se incluyen en `errors[]` con su código original:
+Si el proveedor externo devuelve detalles útiles que Facturapi no puede clasificar de forma confiable, se incluyen en `errors[]` con su código original:
 
 ```json
 {
-  "message": "El RFC del receptor no se encuentra en la lista de RFC inscritos no cancelados del SAT.",
+  "message": "No se encontró el RFC [AAA010101AAA] en la Lista de Contribuyentes Obligados.",
   "status": 400,
   "code": "invoice_stamping_validation_error",
   "errors": [
     {
-      "message": "El RFC del receptor no se encuentra en la lista de RFC inscritos no cancelados del SAT.",
-      "code": "CFDI40145",
-      "source": "sat"
+      "message": "No se encontró el RFC [AAA010101AAA] en la Lista de Contribuyentes Obligados.",
+      "code": "402",
+      "source": "pac"
     }
   ],
   "ok": false

--- a/website/docs/getting-started/errors.mdx
+++ b/website/docs/getting-started/errors.mdx
@@ -20,8 +20,9 @@ La API responde los errores en JSON y usa códigos de estado HTTP estándar. Par
   "path": "customer.email",
   "errors": [
     {
-      "message": "\"customer.email\" is required",
+      "message": "El campo \"customer.email\" es requerido.",
       "code": "required",
+      "source": "facturapi",
       "location": "body",
       "path": "customer.email"
     }
@@ -37,22 +38,22 @@ La API responde los errores en JSON y usa códigos de estado HTTP estándar. Par
 | `code` | `string` | Código raíz estable para manejar el error. |
 | `location` | `string` | Ubicación del dato relacionado con el error, por ejemplo `body`, `query`, `params` o `files`. Sólo se incluye cuando aplica. |
 | `path` | `string` | Ruta del campo relacionado con el error. Sólo se incluye cuando aplica. |
-| `errors` | `array` | Detalles adicionales. Sólo se incluye cuando hay múltiples errores de validación o detalles externos relevantes. |
+| `errors` | `array` | Detalles adicionales. Sólo se incluye cuando hay múltiples errores de validación o detalles relevantes. |
 | `errors[].message` | `string` | Mensaje legible de un detalle. |
 | `errors[].code` | `string` | Subcódigo del detalle. En errores de validación usa un `ValidationErrorCode`; en errores externos puede ser el código original del SAT o PAC. |
 | `errors[].location` | `string` | Ubicación del dato relacionado con el detalle, por ejemplo `body`, `query`, `params` o `files`. |
 | `errors[].path` | `string` | Ruta del campo relacionado con el detalle. |
-| `errors[].source` | `string` | Fuente externa del detalle, por ejemplo `sat` o `pac`. Sólo se incluye para errores externos. |
+| `errors[].source` | `string` | Fuente del detalle. Puede ser `facturapi`, `sat`, `pac` o `stripe`. |
 
 ## Cómo interpretar los códigos
 
 El `code` raíz clasifica el resultado principal de la solicitud y es el valor que deberías usar primero para decidir cómo manejar el error.
 
-Los códigos dentro de `errors[]` son subcódigos de detalle. Sirven para explicar campos inválidos o respuestas externas, pero no reemplazan al `code` raíz. Pueden ser subcódigos de validación definidos por Facturapi o códigos originales de sistemas externos como SAT o PAC.
+Los códigos dentro de `errors[]` son subcódigos de detalle. Sirven para explicar campos inválidos o respuestas externas, pero no reemplazan al `code` raíz. Cuando `source` es `facturapi`, el subcódigo y el mensaje son definidos por Facturapi. Cuando `source` es externo, el subcódigo puede ser el código original del sistema indicado.
 
 ### Errores de validación
 
-Cuando la petición no cumple el contrato de entrada, el error raíz usa `code: "invalid_request"`. Si hay detalles, `errors[]` incluye cada campo inválido con `path`, `location` y un subcódigo de validación.
+Cuando la petición no cumple el contrato de entrada, el error raíz usa `code: "invalid_request"`. Si hay detalles, `errors[]` incluye cada campo inválido con `source: "facturapi"`, `path`, `location` y un subcódigo de validación.
 
 Los subcódigos de validación están documentados al final de esta página como subcódigos de detalle porque aparecen en `errors[].code`, no en `error.code`.
 
@@ -296,12 +297,14 @@ Esta lista es la referencia documentada de códigos raíz públicos de la API. P
 | `certificate_file_required` | No pudimos encontrar un archivo con el nombre "cer" en tu petición. Asegúrate de que tu petición sea de tipo multipart/form-data y de usar "cer" como la llave del atributo. |
 | `certificate_files_invalid` | El certificado o la llave privada no son válidos, están incompletos o están dañados. |
 | `certificate_files_required` | No pudimos encontrar ningún archivo en tu petición. |
+| `certificate_fiel_rfc_mismatch` | El RFC del certificado no coincide con el RFC de la FIEL. |
 | `certificate_invalid` | El certificado no es válido. |
 | `certificate_not_yet_valid` | El certificado aún no puede ser utilizado. |
+| `certificate_previous_rfc_mismatch` | El RFC del certificado no coincide con el certificado anterior. |
 | `certificate_rfc_mismatch` | El RFC del certificado no coincide con la organización. |
 | `csd_required` | El certificado no es un CSD. Asegúrate de no estar enviando una FIEL. |
 | `fiel_invalid` | La FIEL no es válida. |
-| `fiel_rfc_mismatch` | El RFC de la FIEL no coincide con la organización. |
+| `fiel_rfc_mismatch` | El RFC de la FIEL no coincide con el RFC del certificado CSD. |
 | `fiel_required` | El certificado no es una FIEL. Asegúrate de no estar enviando un CSD. |
 | `organization_settings_invalid` | La configuración de la organización no es válida. |
 | `organization_tax_info_invalid` | La información fiscal de la organización no es válida. |
@@ -366,7 +369,9 @@ Estos valores aparecen dentro de `errors[]` para explicar detalles específicos 
 
 ### Validación de entrada
 
-Estos subcódigos pueden aparecer cuando el código raíz es `invalid_request`.
+Estos subcódigos suelen aparecer cuando el código raíz es `invalid_request`,
+pero también pueden aparecer en `errors[]` de otros códigos raíz cuando el
+detalle del error corresponde a campos o valores inválidos.
 
 | Código | Descripción |
 | --- | --- |

--- a/website/docs/getting-started/errors.mdx
+++ b/website/docs/getting-started/errors.mdx
@@ -92,7 +92,7 @@ Algunas respuestas de error incluyen headers útiles para manejo programático u
 | `Retry-After` | Segundos recomendados antes de reintentar. Se incluye en errores con `code: "rate_limit_exceeded"`. |
 | `X-Facturapi-Log-Id` | ID de correlación de la solicitud. Puedes conservarlo en tu observabilidad para investigar errores con soporte. |
 
-## Códigos raíz (`error.code`)
+## Códigos raíz (`code`)
 
 Esta lista es la referencia documentada de códigos raíz públicos de la API. Podemos agregar nuevos códigos en cualquier momento cuando nuevas funcionalidades o nuevos casos de error lo requieran, pero procuramos mantener esta página actualizada para que las integraciones tengan una referencia predecible.
 
@@ -145,7 +145,7 @@ Esta lista es la referencia documentada de códigos raíz públicos de la API. P
 
 ### TaxInfoValidationCode
 
-Estos códigos describen errores de información fiscal validados por Facturapi. Cuando la validación fiscal de un cliente u organización detecta un solo problema, aparece en `error.code`. Las validaciones de entrada y el endpoint de validación de información fiscal de un cliente los devuelven en `errors[].code`.
+Estos códigos describen errores de información fiscal validados por Facturapi. Cuando la validación fiscal de un cliente u organización detecta un solo problema, aparece en `code`. Las validaciones de entrada y el endpoint de validación de información fiscal de un cliente los devuelven en `errors[].code`.
 
 | Código | Descripción |
 | --- | --- |

--- a/website/docs/getting-started/errors.mdx
+++ b/website/docs/getting-started/errors.mdx
@@ -392,6 +392,9 @@ Interpreta el subcódigo junto con `path`, `location` y la petición original; l
 
 | Código | Descripción |
 | --- | --- |
+| `amount_exceeds_related_document_balance` | El monto pagado no puede ser mayor al saldo anterior del documento relacionado. |
+| `exchange_rate_too_large` | El tipo de cambio debe ser menor o igual a 1 cuando el pago está en MXN y el documento relacionado en USD. |
+| `exchange_rate_too_small` | El tipo de cambio debe ser mayor o igual a 1 cuando el pago está en USD y el documento relacionado en MXN. |
 | `invalid_format` | El valor no cumple el formato esperado. |
 | `invalid_length` | El valor no cumple la longitud permitida. |
 | `invalid_type` | El valor no tiene el tipo esperado. |

--- a/website/docs/getting-started/errors.mdx
+++ b/website/docs/getting-started/errors.mdx
@@ -43,7 +43,7 @@ La API responde los errores en JSON y usa códigos de estado HTTP estándar. Par
 | `errors[].code` | `string` | Subcódigo del detalle. En errores de validación usa un `ValidationErrorCode`; en errores externos puede ser el código original del SAT o PAC. |
 | `errors[].location` | `string` | Ubicación del dato relacionado con el detalle, por ejemplo `body`, `query`, `params` o `files`. |
 | `errors[].path` | `string` | Ruta del campo relacionado con el detalle. |
-| `errors[].source` | `string` | Fuente del detalle. Puede ser `facturapi`, `sat`, `pac` o `stripe`. |
+| `errors[].source` | `string` | Fuente del detalle. Puede ser `facturapi`, `sat` o `pac`. |
 
 ## Cómo interpretar los códigos
 
@@ -237,16 +237,17 @@ Esta lista es la referencia documentada de códigos raíz públicos de la API. P
 
 | Código | Descripción |
 | --- | --- |
-| `receipt_invoicing_customer_mismatch` | Los recibos no pueden facturarse juntos para el mismo cliente. |
-| `receipt_invoicing_too_many_items` | Los recibos exceden el límite de conceptos permitidos. |
-| `receipt_keys_not_found` | No se encontraron todos los recibos solicitados. |
+| `receipt_invoicing_address_mismatch` | Todos los recibos deben tener el mismo domicilio de expedición para poder facturarlos juntos. |
+| `receipt_invoicing_customer_mismatch` | Debes enviar un cliente o seleccionar recibos que ya pertenezcan al mismo cliente. |
+| `receipt_invoicing_too_many_items` | Los recibos exceden el máximo de 5,000 conceptos soportados. Divide los recibos en varias facturas. |
+| `receipt_keys_not_found` | No se encontraron los recibos solicitados. Cuando faltan sólo algunas keys, `errors[]` puede indicar su posición con `path: "keys.N"`. |
 
 ### ReceiptGlobalInvoiceErrorCode
 
 | Código | Descripción |
 | --- | --- |
-| `global_invoice_too_many_items` | La factura global excede el límite de conceptos permitidos. |
-| `invalid_global_invoice_period` | El periodo de factura global no es válido. |
+| `global_invoice_too_many_items` | La factura global excede el máximo de 5,000 conceptos soportados. Genera varias facturas globales usando rangos de fechas más pequeños o subconjuntos de recibos. |
+| `invalid_global_invoice_period` | El rango de fechas debe estar dentro del mismo periodo de facturación: `{period}`. |
 
 ### RetentionErrorCode
 
@@ -378,6 +379,7 @@ detalle del error corresponde a campos o valores inválidos.
 | `invalid_format` | El valor no cumple el formato esperado. |
 | `invalid_length` | El valor no cumple la longitud permitida. |
 | `invalid_type` | El valor no tiene el tipo esperado. |
+| `not_found` | El valor referencia un recurso que no existe. |
 | `not_allowed` | El valor no está permitido para este campo. |
 | `required` | Falta un campo requerido. |
 | `too_large` | El valor excede el límite permitido. |

--- a/website/docs/getting-started/errors.mdx
+++ b/website/docs/getting-started/errors.mdx
@@ -4,10 +4,6 @@ sidebar_position: 7
 
 # Manejo de errores
 
-:::info[Vigencia]
-Los códigos y mensajes de error normalizados descritos aquí aplicarán a partir del 2 de julio de 2026. Antes de esa fecha, los códigos y mensajes pueden ser diferentes a los documentados en esta página.
-:::
-
 La API responde los errores en JSON y usa códigos de estado HTTP estándar. Para manejar errores de forma programática, usa `code`: es un string estable y predecible.
 
 `message` está pensado para lectura humana. Puede cambiar para mejorar claridad o soportar localización, así que no debería usarse para branching de lógica.
@@ -296,12 +292,22 @@ Esta lista es la referencia documentada de códigos raíz públicos de la API. P
 
 | Código | Descripción |
 | --- | --- |
+| `certificate_expired` | El certificado ha expirado. |
+| `certificate_file_required` | No pudimos encontrar un archivo con el nombre "cer" en tu petición. Asegúrate de que tu petición sea de tipo multipart/form-data y de usar "cer" como la llave del atributo. |
+| `certificate_files_invalid` | El certificado o la llave privada no son válidos, están incompletos o están dañados. |
+| `certificate_files_required` | No pudimos encontrar ningún archivo en tu petición. |
 | `certificate_invalid` | El certificado no es válido. |
+| `certificate_not_yet_valid` | El certificado aún no puede ser utilizado. |
 | `certificate_rfc_mismatch` | El RFC del certificado no coincide con la organización. |
+| `csd_required` | El certificado no es un CSD. Asegúrate de no estar enviando una FIEL. |
 | `fiel_invalid` | La FIEL no es válida. |
 | `fiel_rfc_mismatch` | El RFC de la FIEL no coincide con la organización. |
+| `fiel_required` | El certificado no es una FIEL. Asegúrate de no estar enviando un CSD. |
 | `organization_settings_invalid` | La configuración de la organización no es válida. |
 | `organization_tax_info_invalid` | La información fiscal de la organización no es válida. |
+| `private_key_certificate_mismatch` | La llave privada no coincide con el certificado. |
+| `private_key_file_required` | No pudimos encontrar un archivo con el nombre "key" en tu petición. Asegúrate de que tu petición sea de tipo multipart/form-data y de usar "key" como la llave del atributo. |
+| `private_key_password_incorrect` | La contraseña de la llave privada es incorrecta. |
 
 ### OrganizationInviteErrorCode
 

--- a/website/docs/getting-started/errors.mdx
+++ b/website/docs/getting-started/errors.mdx
@@ -51,6 +51,8 @@ El `code` raíz clasifica el resultado principal de la solicitud y es el valor q
 
 El arreglo `errors[]` aparece cuando la respuesta necesita explicar uno o más detalles además del resultado principal: por ejemplo, varios campos inválidos en una misma solicitud o los motivos que devolvió un proveedor externo. Sus códigos son subcódigos de detalle y no reemplazan al `code` raíz. Cuando `source` es `facturapi`, el subcódigo y el mensaje son definidos por Facturapi. Cuando `source` es externo, el subcódigo puede ser el código original del sistema indicado.
 
+Cuando el error usa su mensaje raíz por defecto, `message` repite el mensaje del primer detalle de `errors[]`. Esto conserva un mensaje útil para integraciones que todavía no procesan detalles estructurados; para lógica programática, usa siempre `code`, `errors[].code` y `path`.
+
 ### Errores de validación
 
 Cuando la petición no cumple el contrato de entrada, el error raíz usa `code: "invalid_request"`. Si hay detalles, `errors[]` incluye cada campo inválido con `source: "facturapi"`, `path`, `location` y un subcódigo de validación.
@@ -65,7 +67,7 @@ Si el proveedor externo devuelve detalles útiles, se incluyen en `errors[]` con
 
 ```json
 {
-  "message": "La factura no pasó la validación de timbrado.",
+  "message": "El RFC del receptor no se encuentra en la lista de RFC inscritos no cancelados del SAT.",
   "status": 400,
   "code": "invoice_stamping_validation_error",
   "errors": [
@@ -392,13 +394,13 @@ Interpreta el subcódigo junto con `path`, `location` y la petición original; l
 
 ### Validación de información fiscal
 
-Estos subcódigos describen validaciones fiscales realizadas por Facturapi. Pueden aparecer al crear o editar un cliente u organización, y en el resultado de validar la información fiscal de un cliente. Los datos que no cumplen el catálogo se reportan bajo el código raíz de validación del endpoint; los datos que no coinciden con los registros fiscales se reportan bajo `invalid_tax_info`.
+Estos subcódigos describen validaciones fiscales realizadas por Facturapi. Pueden aparecer al crear o editar un cliente u organización, en el resultado de validar la información fiscal de un cliente y al timbrar una factura cuando el rechazo identifica de forma confiable una validación fiscal del receptor. Los datos que no cumplen el catálogo se reportan bajo el código raíz de validación del endpoint; los datos que no coinciden con los registros fiscales se reportan bajo `invalid_tax_info`.
 
 | Código | Descripción |
 | --- | --- |
 | `legal_name_mismatch` | La razón social no corresponde al RFC en los registros del SAT. |
 | `tax_address_zip_mismatch` | El código postal fiscal no corresponde al RFC en los registros del SAT. |
-| `tax_id_not_found` | No se encontró el RFC en los registros del SAT. |
+| `tax_id_not_found` | Este RFC del receptor no existe en la lista de RFC inscritos no cancelados del SAT. |
 | `tax_system_not_allowed_for_tax_id` | El régimen fiscal no está permitido para el RFC en los registros del SAT. |
 | `tax_system_not_in_catalog` | El régimen fiscal no pertenece al catálogo del SAT. |
 

--- a/website/docs/getting-started/errors.mdx
+++ b/website/docs/getting-started/errors.mdx
@@ -6,7 +6,7 @@ sidebar_position: 7
 
 La API responde los errores en JSON y usa códigos de estado HTTP estándar. Para manejar errores de forma programática, usa `code`: es un string estable y predecible.
 
-`message` está pensado para lectura humana. Puede cambiar para mejorar claridad o soportar localización, así que no debería usarse para branching de lógica.
+`message` está pensado para lectura humana. Hoy los mensajes de la API se devuelven en español. Pueden cambiar para mejorar claridad o soportar localización, así que no deberían usarse para branching de lógica.
 
 ## Objeto de error
 

--- a/website/docs/getting-started/errors.mdx
+++ b/website/docs/getting-started/errors.mdx
@@ -136,13 +136,24 @@ Esta lista es la referencia documentada de códigos raíz públicos de la API. P
 | `invalid_image_file` | El archivo proporcionado no es una imagen válida. |
 | `invalid_json` | El JSON enviado no es válido. |
 | `invalid_request` | La solicitud no es válida. |
-| `invalid_tax_info` | La información fiscal no es válida. |
 | `invalid_multipart_form_data` | Los datos multipart/form-data no son válidos. |
 | `invalid_state_code` | El código de estado no es válido. |
 | `invalid_timezone` | La zona horaria no es válida. |
 | `multipart_limit_exceeded` | La solicitud multipart/form-data excede los límites permitidos. |
 | `page_too_large` | La página solicitada excede el límite permitido. |
 | `payload_too_large` | El payload excede el tamaño máximo permitido. |
+
+### TaxInfoValidationCode
+
+Estos códigos describen errores de información fiscal validados por Facturapi. Cuando la validación fiscal de un cliente u organización detecta un solo problema, aparece en `error.code`. Las validaciones de entrada y el endpoint de validación de información fiscal de un cliente los devuelven en `errors[].code`.
+
+| Código | Descripción |
+| --- | --- |
+| `legal_name_mismatch` | El nombre, denominación o razón social no corresponde al RFC en los registros del SAT. Verifica que coincida exactamente con la Constancia de Situación Fiscal. |
+| `tax_address_zip_mismatch` | El código postal fiscal no corresponde al RFC en los registros del SAT. |
+| `tax_id_not_found` | Este RFC del receptor no existe en la lista de RFC inscritos no cancelados del SAT. |
+| `tax_system_not_allowed_for_tax_id` | El régimen fiscal no está permitido para el RFC en los registros del SAT. |
+| `tax_system_not_in_catalog` | El régimen fiscal no pertenece al catálogo del SAT. |
 
 ### CustomerErrorCode
 
@@ -391,18 +402,6 @@ Interpreta el subcódigo junto con `path`, `location` y la petición original; l
 | `too_small` | El valor está por debajo del mínimo permitido. |
 | `unknown_field` | El campo no está permitido en esta petición. |
 | `invalid_value` | El valor no es válido. |
-
-### Validación de información fiscal
-
-Estos subcódigos describen validaciones fiscales realizadas por Facturapi. Pueden aparecer al crear o editar un cliente u organización, en el resultado de validar la información fiscal de un cliente y al timbrar una factura cuando el rechazo identifica de forma confiable una validación fiscal del receptor. Los datos que no cumplen el catálogo se reportan bajo el código raíz de validación del endpoint; los datos que no coinciden con los registros fiscales se reportan bajo `invalid_tax_info`.
-
-| Código | Descripción |
-| --- | --- |
-| `legal_name_mismatch` | La razón social no corresponde al RFC en los registros del SAT. |
-| `tax_address_zip_mismatch` | El código postal fiscal no corresponde al RFC en los registros del SAT. |
-| `tax_id_not_found` | Este RFC del receptor no existe en la lista de RFC inscritos no cancelados del SAT. |
-| `tax_system_not_allowed_for_tax_id` | El régimen fiscal no está permitido para el RFC en los registros del SAT. |
-| `tax_system_not_in_catalog` | El régimen fiscal no pertenece al catálogo del SAT. |
 
 ### Códigos externos
 

--- a/website/docs/getting-started/errors.mdx
+++ b/website/docs/getting-started/errors.mdx
@@ -38,7 +38,7 @@ La API responde los errores en JSON y usa códigos de estado HTTP estándar. Par
 | `code` | `string` | Código raíz estable para manejar el error. |
 | `location` | `string` | Ubicación del dato relacionado con el error, por ejemplo `body`, `query`, `params` o `files`. Sólo se incluye cuando aplica. |
 | `path` | `string` | Ruta del campo relacionado con el error. Sólo se incluye cuando aplica. |
-| `errors` | `array` | Detalles adicionales. Sólo se incluye cuando aporta información útil. |
+| `errors` | `array` | Detalles accionables para corregir la solicitud o entender una respuesta externa. Puede incluir varios elementos cuando se detectan varios problemas. |
 | `errors[].message` | `string` | Mensaje legible de un detalle. |
 | `errors[].code` | `string` | Subcódigo del detalle. En validaciones de Facturapi usa un subcódigo de validación de entrada o de información fiscal; en errores externos puede ser el código original del SAT o PAC. |
 | `errors[].location` | `string` | Ubicación del dato relacionado con el detalle, por ejemplo `body`, `query`, `params` o `files`. |
@@ -49,7 +49,7 @@ La API responde los errores en JSON y usa códigos de estado HTTP estándar. Par
 
 El `code` raíz clasifica el resultado principal de la solicitud y es el valor que deberías usar primero para decidir cómo manejar el error.
 
-Los códigos dentro de `errors[]` son subcódigos de detalle. Sirven para explicar campos inválidos o respuestas externas, pero no reemplazan al `code` raíz. Cuando `source` es `facturapi`, el subcódigo y el mensaje son definidos por Facturapi. Cuando `source` es externo, el subcódigo puede ser el código original del sistema indicado.
+El arreglo `errors[]` aparece cuando la respuesta necesita explicar uno o más detalles además del resultado principal: por ejemplo, varios campos inválidos en una misma solicitud o los motivos que devolvió un proveedor externo. Sus códigos son subcódigos de detalle y no reemplazan al `code` raíz. Cuando `source` es `facturapi`, el subcódigo y el mensaje son definidos por Facturapi. Cuando `source` es externo, el subcódigo puede ser el código original del sistema indicado.
 
 ### Errores de validación
 
@@ -378,9 +378,7 @@ Estos valores aparecen dentro de `errors[]` para explicar detalles específicos 
 
 ### Validación de entrada
 
-Estos subcódigos suelen aparecer cuando el código raíz es `invalid_request`,
-pero también pueden aparecer en `errors[]` de otros códigos raíz cuando el
-detalle del error corresponde a campos o valores inválidos.
+Cuando una solicitud tiene varios campos o valores inválidos, `errors[]` incluye un detalle por cada uno. Estos subcódigos identifican el problema de cada detalle.
 
 Interpreta el subcódigo junto con `path`, `location` y la petición original; los subcódigos son deliberadamente generales y no cambian según el tipo del campo o el flujo del endpoint.
 

--- a/website/docs/getting-started/errors.mdx
+++ b/website/docs/getting-started/errors.mdx
@@ -55,7 +55,7 @@ Los códigos dentro de `errors[]` son subcódigos de detalle. Sirven para explic
 
 Cuando la petición no cumple el contrato de entrada, el error raíz usa `code: "invalid_request"`. Si hay detalles, `errors[]` incluye cada campo inválido con `source: "facturapi"`, `path`, `location` y un subcódigo de validación.
 
-Los subcódigos de validación están documentados al final de esta página como subcódigos de detalle porque aparecen en `errors[].code`, no en `error.code`.
+Los subcódigos de validación están documentados al final de esta página como subcódigos de detalle porque aparecen en `errors[].code`, no en el `code` raíz.
 
 ### Errores externos
 

--- a/website/docs/getting-started/errors.mdx
+++ b/website/docs/getting-started/errors.mdx
@@ -134,6 +134,7 @@ Esta lista es la referencia documentada de códigos raíz públicos de la API. P
 | `invalid_image_file` | El archivo proporcionado no es una imagen válida. |
 | `invalid_json` | El JSON enviado no es válido. |
 | `invalid_request` | La solicitud no es válida. |
+| `invalid_tax_info` | La información fiscal no es válida. |
 | `invalid_multipart_form_data` | Los datos multipart/form-data no son válidos. |
 | `invalid_state_code` | El código de estado no es válido. |
 | `invalid_timezone` | La zona horaria no es válida. |
@@ -152,12 +153,6 @@ Esta lista es la referencia documentada de códigos raíz públicos de la API. P
 | `customer_has_invoices` | No se puede eliminar un cliente con facturas asociadas. |
 | `customer_not_found` | No se encontró el cliente. |
 | `customer_tax_info_unavailable` | La información fiscal del cliente no está disponible. |
-
-### TaxInfoErrorCode
-
-| Código | Descripción |
-| --- | --- |
-| `invalid_tax_info` | La información fiscal no es válida. |
 
 ### ProductErrorCode
 

--- a/website/docs/getting-started/errors.mdx
+++ b/website/docs/getting-started/errors.mdx
@@ -13,7 +13,7 @@ La API responde los errores en JSON y usa códigos de estado HTTP estándar. Par
 ```json
 {
   "ok": false,
-  "message": "La solicitud no es válida.",
+  "message": "El campo \"customer.email\" es requerido.",
   "status": 400,
   "code": "invalid_request",
   "location": "body",
@@ -38,9 +38,9 @@ La API responde los errores en JSON y usa códigos de estado HTTP estándar. Par
 | `code` | `string` | Código raíz estable para manejar el error. |
 | `location` | `string` | Ubicación del dato relacionado con el error, por ejemplo `body`, `query`, `params` o `files`. Sólo se incluye cuando aplica. |
 | `path` | `string` | Ruta del campo relacionado con el error. Sólo se incluye cuando aplica. |
-| `errors` | `array` | Detalles adicionales. Sólo se incluye cuando hay múltiples errores de validación o detalles relevantes. |
+| `errors` | `array` | Detalles adicionales. Sólo se incluye cuando aporta información útil. |
 | `errors[].message` | `string` | Mensaje legible de un detalle. |
-| `errors[].code` | `string` | Subcódigo del detalle. En errores de validación usa un `ValidationErrorCode`; en errores externos puede ser el código original del SAT o PAC. |
+| `errors[].code` | `string` | Subcódigo del detalle. En validaciones de Facturapi usa un subcódigo de validación de entrada o de información fiscal; en errores externos puede ser el código original del SAT o PAC. |
 | `errors[].location` | `string` | Ubicación del dato relacionado con el detalle, por ejemplo `body`, `query`, `params` o `files`. |
 | `errors[].path` | `string` | Ruta del campo relacionado con el detalle. |
 | `errors[].source` | `string` | Fuente del detalle. Puede ser `facturapi`, `sat` o `pac`. |
@@ -152,6 +152,12 @@ Esta lista es la referencia documentada de códigos raíz públicos de la API. P
 | `customer_has_invoices` | No se puede eliminar un cliente con facturas asociadas. |
 | `customer_not_found` | No se encontró el cliente. |
 | `customer_tax_info_unavailable` | La información fiscal del cliente no está disponible. |
+
+### TaxInfoErrorCode
+
+| Código | Descripción |
+| --- | --- |
+| `invalid_tax_info` | La información fiscal no es válida. |
 
 ### ProductErrorCode
 
@@ -302,12 +308,14 @@ Esta lista es la referencia documentada de códigos raíz públicos de la API. P
 | `certificate_invalid` | El certificado no es válido. |
 | `certificate_not_yet_valid` | El certificado aún no puede ser utilizado. |
 | `certificate_previous_rfc_mismatch` | El RFC del certificado no coincide con el certificado anterior. |
-| `certificate_rfc_mismatch` | El RFC del certificado no coincide con la organización. |
 | `csd_required` | El certificado no es un CSD. Asegúrate de no estar enviando una FIEL. |
 | `fiel_invalid` | La FIEL no es válida. |
 | `fiel_rfc_mismatch` | El RFC de la FIEL no coincide con el RFC del certificado CSD. |
 | `fiel_required` | El certificado no es una FIEL. Asegúrate de no estar enviando un CSD. |
+| `organization_domain_change_not_allowed` | El dominio de facturación no se puede modificar una vez elegido. Contáctanos para cambiarlo. |
+| `organization_domain_unavailable` | El dominio de facturación no está disponible. |
 | `organization_settings_invalid` | La configuración de la organización no es válida. |
+| `organization_support_email_required` | Se requiere un correo de soporte para elegir un dominio de facturación. |
 | `organization_tax_info_invalid` | La información fiscal de la organización no es válida. |
 | `private_key_certificate_mismatch` | La llave privada no coincide con el certificado. |
 | `private_key_file_required` | No pudimos encontrar un archivo con el nombre "key" en tu petición. Asegúrate de que tu petición sea de tipo multipart/form-data y de usar "key" como la llave del atributo. |
@@ -374,6 +382,8 @@ Estos subcódigos suelen aparecer cuando el código raíz es `invalid_request`,
 pero también pueden aparecer en `errors[]` de otros códigos raíz cuando el
 detalle del error corresponde a campos o valores inválidos.
 
+Interpreta el subcódigo junto con `path`, `location` y la petición original; los subcódigos son deliberadamente generales y no cambian según el tipo del campo o el flujo del endpoint.
+
 | Código | Descripción |
 | --- | --- |
 | `invalid_format` | El valor no cumple el formato esperado. |
@@ -385,6 +395,19 @@ detalle del error corresponde a campos o valores inválidos.
 | `too_large` | El valor excede el límite permitido. |
 | `too_small` | El valor está por debajo del mínimo permitido. |
 | `unknown_field` | El campo no está permitido en esta petición. |
+| `invalid_value` | El valor no es válido. |
+
+### Validación de información fiscal
+
+Estos subcódigos describen validaciones fiscales realizadas por Facturapi. Pueden aparecer al crear o editar un cliente u organización, y en el resultado de validar la información fiscal de un cliente. Los datos que no cumplen el catálogo se reportan bajo el código raíz de validación del endpoint; los datos que no coinciden con los registros fiscales se reportan bajo `invalid_tax_info`.
+
+| Código | Descripción |
+| --- | --- |
+| `legal_name_mismatch` | La razón social no corresponde al RFC en los registros del SAT. |
+| `tax_address_zip_mismatch` | El código postal fiscal no corresponde al RFC en los registros del SAT. |
+| `tax_id_not_found` | No se encontró el RFC en los registros del SAT. |
+| `tax_system_not_allowed_for_tax_id` | El régimen fiscal no está permitido para el RFC en los registros del SAT. |
+| `tax_system_not_in_catalog` | El régimen fiscal no pertenece al catálogo del SAT. |
 
 ### Códigos externos
 

--- a/website/docs/getting-started/errors.mdx
+++ b/website/docs/getting-started/errors.mdx
@@ -149,7 +149,7 @@ Estos códigos describen errores de información fiscal validados por Facturapi.
 
 | Código | Descripción |
 | --- | --- |
-| `legal_name_mismatch` | El nombre, denominación o razón social no corresponde al RFC en los registros del SAT. Verifica que coincida exactamente con la Constancia de Situación Fiscal. |
+| `legal_name_mismatch` | El nombre o razón social no corresponde al RFC en los registros del SAT. Verifica que coincida exactamente con la Constancia de Situación Fiscal. |
 | `tax_address_zip_mismatch` | El código postal fiscal no corresponde al RFC en los registros del SAT. |
 | `tax_id_not_found` | Este RFC del receptor no existe en la lista de RFC inscritos no cancelados del SAT. |
 | `tax_system_not_allowed_for_tax_id` | El régimen fiscal no está permitido para el RFC en los registros del SAT. |

--- a/website/i18n/en/docusaurus-plugin-content-docs/current/getting-started/errors.mdx
+++ b/website/i18n/en/docusaurus-plugin-content-docs/current/getting-started/errors.mdx
@@ -43,7 +43,7 @@ The API returns errors as JSON and uses standard HTTP status codes. For programm
 | `errors[].code` | `string` | Detail subcode. For validation errors, this uses a `ValidationErrorCode`; for external errors, it may be the original SAT or PAC code. |
 | `errors[].location` | `string` | Location of the data related to the detail, such as `body`, `query`, `params`, or `files`. |
 | `errors[].path` | `string` | Path of the field related to the detail. |
-| `errors[].source` | `string` | Source of the detail. It can be `facturapi`, `sat`, `pac`, or `stripe`. |
+| `errors[].source` | `string` | Source of the detail. It can be `facturapi`, `sat`, or `pac`. |
 
 ## Interpreting codes
 
@@ -237,16 +237,17 @@ This list is the documented reference for public root API codes. We may add new 
 
 | Code | Description |
 | --- | --- |
-| `receipt_invoicing_customer_mismatch` | The receipts cannot be invoiced together for the same customer. |
-| `receipt_invoicing_too_many_items` | The receipts exceed the allowed item limit. |
-| `receipt_keys_not_found` | Not all requested receipt keys were found. |
+| `receipt_invoicing_address_mismatch` | All receipts must have the same expedition address to be invoiced together. |
+| `receipt_invoicing_customer_mismatch` | Send a customer or select receipts that already belong to the same customer. |
+| `receipt_invoicing_too_many_items` | The receipts exceed the maximum of 5,000 supported items. Split the receipts into multiple invoices. |
+| `receipt_keys_not_found` | The requested receipts were not found. When only some keys are missing, `errors[]` may point to their position with `path: "keys.N"`. |
 
 ### ReceiptGlobalInvoiceErrorCode
 
 | Code | Description |
 | --- | --- |
-| `global_invoice_too_many_items` | The global invoice exceeds the allowed item limit. |
-| `invalid_global_invoice_period` | The global invoice period is invalid. |
+| `global_invoice_too_many_items` | The global invoice exceeds the maximum of 5,000 supported items. Create multiple global invoices using smaller date ranges or receipt subsets. |
+| `invalid_global_invoice_period` | The date range must be within the same billing period: `{period}`. |
 
 ### RetentionErrorCode
 
@@ -378,6 +379,7 @@ invalid fields or values.
 | `invalid_format` | The value does not match the expected format. |
 | `invalid_length` | The value does not match the allowed length. |
 | `invalid_type` | The value has the wrong type. |
+| `not_found` | The value references a resource that does not exist. |
 | `not_allowed` | The value is not allowed for this field. |
 | `required` | A required field is missing. |
 | `too_large` | The value exceeds the allowed limit. |

--- a/website/i18n/en/docusaurus-plugin-content-docs/current/getting-started/errors.mdx
+++ b/website/i18n/en/docusaurus-plugin-content-docs/current/getting-started/errors.mdx
@@ -136,13 +136,24 @@ This list is the documented reference for public root API codes. We may add new 
 | `invalid_image_file` | The provided file is not a valid image. |
 | `invalid_json` | The request body is not valid JSON. |
 | `invalid_request` | The request is invalid. |
-| `invalid_tax_info` | The tax information is invalid. |
 | `invalid_multipart_form_data` | The multipart/form-data payload is invalid. |
 | `invalid_state_code` | The state code is invalid. |
 | `invalid_timezone` | The timezone is invalid. |
 | `multipart_limit_exceeded` | The multipart/form-data request exceeds the allowed limits. |
 | `page_too_large` | The requested page exceeds the allowed limit. |
 | `payload_too_large` | The request payload exceeds the maximum allowed size. |
+
+### TaxInfoValidationCode
+
+These codes describe tax-information errors validated by Facturapi. When a customer or organization tax-information validation detects a single issue, it appears in `error.code`. Input validations and the customer tax-information validation endpoint return them in `errors[].code`.
+
+| Code | Description |
+| --- | --- |
+| `legal_name_mismatch` | The name, corporate name, or business name does not match the RFC in SAT records. Verify that it exactly matches the Tax Status Certificate (Constancia de Situación Fiscal). |
+| `tax_address_zip_mismatch` | The fiscal zip code does not match the RFC in SAT records. |
+| `tax_id_not_found` | The receiver RFC does not exist in SAT's list of registered, non-cancelled RFCs. |
+| `tax_system_not_allowed_for_tax_id` | The tax regime is not allowed for the RFC in SAT records. |
+| `tax_system_not_in_catalog` | The tax regime does not belong to the SAT catalog. |
 
 ### CustomerErrorCode
 
@@ -391,18 +402,6 @@ Interpret the subcode together with `path`, `location`, and the original request
 | `too_small` | The value is below the allowed minimum. |
 | `unknown_field` | The field is not allowed in this request. |
 | `invalid_value` | The value is invalid. |
-
-### Tax information validation
-
-These subcodes describe tax information validations performed by Facturapi. They may appear when creating or editing a customer or organization, in the result of validating a customer's tax information, and while stamping an invoice when a rejection reliably identifies a receiver tax-information validation. Values outside the catalog are reported under the endpoint's validation root code; values that do not match tax records are reported under `invalid_tax_info`.
-
-| Code | Description |
-| --- | --- |
-| `legal_name_mismatch` | The legal name does not match the RFC in SAT records. |
-| `tax_address_zip_mismatch` | The fiscal zip code does not match the RFC in SAT records. |
-| `tax_id_not_found` | The receiver RFC does not exist in SAT's list of registered, non-cancelled RFCs. |
-| `tax_system_not_allowed_for_tax_id` | The tax regime is not allowed for the RFC in SAT records. |
-| `tax_system_not_in_catalog` | The tax regime does not belong to the SAT catalog. |
 
 ### External codes
 

--- a/website/i18n/en/docusaurus-plugin-content-docs/current/getting-started/errors.mdx
+++ b/website/i18n/en/docusaurus-plugin-content-docs/current/getting-started/errors.mdx
@@ -20,7 +20,7 @@ The API returns errors as JSON and uses standard HTTP status codes. For programm
   "path": "customer.email",
   "errors": [
     {
-      "message": "El campo \"customer.email\" es requerido.",
+      "message": "The field \"customer.email\" is required.",
       "code": "required",
       "source": "facturapi",
       "location": "body",
@@ -296,7 +296,7 @@ This list is the documented reference for public root API codes. We may add new 
 | --- | --- |
 | `certificate_expired` | The certificate has expired. |
 | `certificate_file_required` | We could not find a file named "cer" in your request. Make sure your request uses multipart/form-data and uses "cer" as the field name. |
-| `certificate_files_invalid` | The certificate or private key are invalid, incomplete, or damaged. |
+| `certificate_files_invalid` | The certificate or private key is invalid, incomplete, or damaged. |
 | `certificate_files_required` | We could not find any files in your request. |
 | `certificate_fiel_rfc_mismatch` | The certificate RFC does not match the FIEL RFC. |
 | `certificate_invalid` | The certificate is invalid. |

--- a/website/i18n/en/docusaurus-plugin-content-docs/current/getting-started/errors.mdx
+++ b/website/i18n/en/docusaurus-plugin-content-docs/current/getting-started/errors.mdx
@@ -4,10 +4,6 @@ sidebar_position: 7
 
 # Error handling
 
-:::info[Availability]
-The normalized error codes and messages described here apply starting July 2, 2026. Before that date, error codes and messages may differ from what is documented on this page.
-:::
-
 The API returns errors as JSON and uses standard HTTP status codes. For programmatic error handling, use `code`: it is a stable, predictable string.
 
 `message` is meant for humans. It may change to improve clarity or support localization, so avoid using it for branching logic.
@@ -296,12 +292,22 @@ This list is the documented reference for public root API codes. We may add new 
 
 | Code | Description |
 | --- | --- |
+| `certificate_expired` | The certificate has expired. |
+| `certificate_file_required` | We could not find a file named "cer" in your request. Make sure your request uses multipart/form-data and uses "cer" as the field name. |
+| `certificate_files_invalid` | The certificate or private key are invalid, incomplete, or damaged. |
+| `certificate_files_required` | We could not find any files in your request. |
 | `certificate_invalid` | The certificate is invalid. |
+| `certificate_not_yet_valid` | The certificate cannot be used yet. |
 | `certificate_rfc_mismatch` | The certificate RFC does not match the organization. |
+| `csd_required` | The certificate is not a CSD. Make sure you are not sending a FIEL. |
 | `fiel_invalid` | The FIEL is invalid. |
 | `fiel_rfc_mismatch` | The FIEL RFC does not match the organization. |
+| `fiel_required` | The certificate is not a FIEL. Make sure you are not sending a CSD. |
 | `organization_settings_invalid` | The organization settings are invalid. |
 | `organization_tax_info_invalid` | The organization tax information is invalid. |
+| `private_key_certificate_mismatch` | The private key does not match the certificate. |
+| `private_key_file_required` | We could not find a file named "key" in your request. Make sure your request uses multipart/form-data and uses "key" as the field name. |
+| `private_key_password_incorrect` | The private key password is incorrect. |
 
 ### OrganizationInviteErrorCode
 

--- a/website/i18n/en/docusaurus-plugin-content-docs/current/getting-started/errors.mdx
+++ b/website/i18n/en/docusaurus-plugin-content-docs/current/getting-started/errors.mdx
@@ -6,7 +6,7 @@ sidebar_position: 7
 
 The API returns errors as JSON and uses standard HTTP status codes. For programmatic error handling, use `code`: it is a stable, predictable string.
 
-`message` is meant for humans. It may change to improve clarity or support localization, so avoid using it for branching logic.
+`message` is meant for humans. Today, API messages are returned in Spanish. They may change to improve clarity or support localization, so avoid using them for branching logic.
 
 ## Error object
 
@@ -20,7 +20,7 @@ The API returns errors as JSON and uses standard HTTP status codes. For programm
   "path": "customer.email",
   "errors": [
     {
-      "message": "The field \"customer.email\" is required.",
+      "message": "El campo \"customer.email\" es requerido.",
       "code": "required",
       "source": "facturapi",
       "location": "body",

--- a/website/i18n/en/docusaurus-plugin-content-docs/current/getting-started/errors.mdx
+++ b/website/i18n/en/docusaurus-plugin-content-docs/current/getting-started/errors.mdx
@@ -392,6 +392,9 @@ Interpret the subcode together with `path`, `location`, and the original request
 
 | Code | Description |
 | --- | --- |
+| `amount_exceeds_related_document_balance` | The paid amount cannot exceed the related document's previous balance. |
+| `exchange_rate_too_large` | The exchange rate must be less than or equal to 1 when the payment is in MXN and the related document is in USD. |
+| `exchange_rate_too_small` | The exchange rate must be greater than or equal to 1 when the payment is in USD and the related document is in MXN. |
 | `invalid_format` | The value does not match the expected format. |
 | `invalid_length` | The value does not match the allowed length. |
 | `invalid_type` | The value has the wrong type. |

--- a/website/i18n/en/docusaurus-plugin-content-docs/current/getting-started/errors.mdx
+++ b/website/i18n/en/docusaurus-plugin-content-docs/current/getting-started/errors.mdx
@@ -20,8 +20,9 @@ The API returns errors as JSON and uses standard HTTP status codes. For programm
   "path": "customer.email",
   "errors": [
     {
-      "message": "\"customer.email\" is required",
+      "message": "El campo \"customer.email\" es requerido.",
       "code": "required",
+      "source": "facturapi",
       "location": "body",
       "path": "customer.email"
     }
@@ -37,22 +38,22 @@ The API returns errors as JSON and uses standard HTTP status codes. For programm
 | `code` | `string` | Stable root code for handling the error. |
 | `location` | `string` | Location of the data related to the error, such as `body`, `query`, `params`, or `files`. Included only when applicable. |
 | `path` | `string` | Path of the field related to the error. Included only when applicable. |
-| `errors` | `array` | Additional details. Included only when there are multiple validation errors or relevant external details. |
+| `errors` | `array` | Additional details. Included only when there are multiple validation errors or relevant details. |
 | `errors[].message` | `string` | Human-readable message for a detail. |
 | `errors[].code` | `string` | Detail subcode. For validation errors, this uses a `ValidationErrorCode`; for external errors, it may be the original SAT or PAC code. |
 | `errors[].location` | `string` | Location of the data related to the detail, such as `body`, `query`, `params`, or `files`. |
 | `errors[].path` | `string` | Path of the field related to the detail. |
-| `errors[].source` | `string` | External source for the detail, such as `sat` or `pac`. Included only for external errors. |
+| `errors[].source` | `string` | Source of the detail. It can be `facturapi`, `sat`, `pac`, or `stripe`. |
 
 ## Interpreting codes
 
 The root `code` classifies the main result of the request and is the value you should check first when deciding how to handle an error.
 
-Codes inside `errors[]` are detail subcodes. They explain invalid fields or external responses, but they do not replace the root `code`. They may be Facturapi validation subcodes or original codes from external systems such as SAT or PAC.
+Codes inside `errors[]` are detail subcodes. They explain invalid fields or external responses, but they do not replace the root `code`. When `source` is `facturapi`, the subcode and message are defined by Facturapi. When `source` is external, the subcode may be the original code from the indicated system.
 
 ### Validation errors
 
-When the request does not match the input contract, the root error uses `code: "invalid_request"`. When details are available, `errors[]` includes each invalid field with `path`, `location`, and a validation subcode.
+When the request does not match the input contract, the root error uses `code: "invalid_request"`. When details are available, `errors[]` includes each invalid field with `source: "facturapi"`, `path`, `location`, and a validation subcode.
 
 Validation subcodes are documented at the end of this page as detail subcodes because they appear in `errors[].code`, not in `error.code`.
 
@@ -296,12 +297,14 @@ This list is the documented reference for public root API codes. We may add new 
 | `certificate_file_required` | We could not find a file named "cer" in your request. Make sure your request uses multipart/form-data and uses "cer" as the field name. |
 | `certificate_files_invalid` | The certificate or private key are invalid, incomplete, or damaged. |
 | `certificate_files_required` | We could not find any files in your request. |
+| `certificate_fiel_rfc_mismatch` | The certificate RFC does not match the FIEL RFC. |
 | `certificate_invalid` | The certificate is invalid. |
 | `certificate_not_yet_valid` | The certificate cannot be used yet. |
+| `certificate_previous_rfc_mismatch` | The certificate RFC does not match the previous certificate. |
 | `certificate_rfc_mismatch` | The certificate RFC does not match the organization. |
 | `csd_required` | The certificate is not a CSD. Make sure you are not sending a FIEL. |
 | `fiel_invalid` | The FIEL is invalid. |
-| `fiel_rfc_mismatch` | The FIEL RFC does not match the organization. |
+| `fiel_rfc_mismatch` | The FIEL RFC does not match the CSD certificate RFC. |
 | `fiel_required` | The certificate is not a FIEL. Make sure you are not sending a CSD. |
 | `organization_settings_invalid` | The organization settings are invalid. |
 | `organization_tax_info_invalid` | The organization tax information is invalid. |
@@ -366,7 +369,9 @@ These values appear inside `errors[]` to explain specific details of the root er
 
 ### Input validation
 
-These subcodes may appear when the root code is `invalid_request`.
+These subcodes usually appear when the root code is `invalid_request`, but they
+may also appear in `errors[]` for other root codes when the error detail is about
+invalid fields or values.
 
 | Code | Description |
 | --- | --- |

--- a/website/i18n/en/docusaurus-plugin-content-docs/current/getting-started/errors.mdx
+++ b/website/i18n/en/docusaurus-plugin-content-docs/current/getting-started/errors.mdx
@@ -13,7 +13,7 @@ The API returns errors as JSON and uses standard HTTP status codes. For programm
 ```json
 {
   "ok": false,
-  "message": "La solicitud no es válida.",
+  "message": "El campo \"customer.email\" es requerido.",
   "status": 400,
   "code": "invalid_request",
   "location": "body",
@@ -38,9 +38,9 @@ The API returns errors as JSON and uses standard HTTP status codes. For programm
 | `code` | `string` | Stable root code for handling the error. |
 | `location` | `string` | Location of the data related to the error, such as `body`, `query`, `params`, or `files`. Included only when applicable. |
 | `path` | `string` | Path of the field related to the error. Included only when applicable. |
-| `errors` | `array` | Additional details. Included only when there are multiple validation errors or relevant details. |
+| `errors` | `array` | Additional details. Included only when they provide useful information. |
 | `errors[].message` | `string` | Human-readable message for a detail. |
-| `errors[].code` | `string` | Detail subcode. For validation errors, this uses a `ValidationErrorCode`; for external errors, it may be the original SAT or PAC code. |
+| `errors[].code` | `string` | Detail subcode. Facturapi validation errors use an input-validation or tax-information-validation subcode; external errors may use the original SAT or PAC code. |
 | `errors[].location` | `string` | Location of the data related to the detail, such as `body`, `query`, `params`, or `files`. |
 | `errors[].path` | `string` | Path of the field related to the detail. |
 | `errors[].source` | `string` | Source of the detail. It can be `facturapi`, `sat`, or `pac`. |
@@ -152,6 +152,12 @@ This list is the documented reference for public root API codes. We may add new 
 | `customer_has_invoices` | The customer cannot be deleted because it has associated invoices. |
 | `customer_not_found` | The customer was not found. |
 | `customer_tax_info_unavailable` | The customer tax information is not available. |
+
+### TaxInfoErrorCode
+
+| Code | Description |
+| --- | --- |
+| `invalid_tax_info` | The tax information is invalid. |
 
 ### ProductErrorCode
 
@@ -302,12 +308,14 @@ This list is the documented reference for public root API codes. We may add new 
 | `certificate_invalid` | The certificate is invalid. |
 | `certificate_not_yet_valid` | The certificate cannot be used yet. |
 | `certificate_previous_rfc_mismatch` | The certificate RFC does not match the previous certificate. |
-| `certificate_rfc_mismatch` | The certificate RFC does not match the organization. |
 | `csd_required` | The certificate is not a CSD. Make sure you are not sending a FIEL. |
 | `fiel_invalid` | The FIEL is invalid. |
 | `fiel_rfc_mismatch` | The FIEL RFC does not match the CSD certificate RFC. |
 | `fiel_required` | The certificate is not a FIEL. Make sure you are not sending a CSD. |
+| `organization_domain_change_not_allowed` | The invoicing domain cannot be changed after it has been selected. Contact us to change it. |
+| `organization_domain_unavailable` | The invoicing domain is not available. |
 | `organization_settings_invalid` | The organization settings are invalid. |
+| `organization_support_email_required` | A support email is required to select an invoicing domain. |
 | `organization_tax_info_invalid` | The organization tax information is invalid. |
 | `private_key_certificate_mismatch` | The private key does not match the certificate. |
 | `private_key_file_required` | We could not find a file named "key" in your request. Make sure your request uses multipart/form-data and uses "key" as the field name. |
@@ -374,6 +382,8 @@ These subcodes usually appear when the root code is `invalid_request`, but they
 may also appear in `errors[]` for other root codes when the error detail is about
 invalid fields or values.
 
+Interpret the subcode together with `path`, `location`, and the original request. Subcodes are intentionally generic and do not change based on the field type or endpoint flow.
+
 | Code | Description |
 | --- | --- |
 | `invalid_format` | The value does not match the expected format. |
@@ -385,6 +395,19 @@ invalid fields or values.
 | `too_large` | The value exceeds the allowed limit. |
 | `too_small` | The value is below the allowed minimum. |
 | `unknown_field` | The field is not allowed in this request. |
+| `invalid_value` | The value is invalid. |
+
+### Tax information validation
+
+These subcodes describe tax information validations performed by Facturapi. They may appear when creating or editing a customer or organization, and in the result of validating a customer's tax information. Values outside the catalog are reported under the endpoint's validation root code; values that do not match tax records are reported under `invalid_tax_info`.
+
+| Code | Description |
+| --- | --- |
+| `legal_name_mismatch` | The legal name does not match the RFC in SAT records. |
+| `tax_address_zip_mismatch` | The fiscal zip code does not match the RFC in SAT records. |
+| `tax_id_not_found` | The RFC was not found in SAT records. |
+| `tax_system_not_allowed_for_tax_id` | The tax regime is not allowed for the RFC in SAT records. |
+| `tax_system_not_in_catalog` | The tax regime does not belong to the SAT catalog. |
 
 ### External codes
 

--- a/website/i18n/en/docusaurus-plugin-content-docs/current/getting-started/errors.mdx
+++ b/website/i18n/en/docusaurus-plugin-content-docs/current/getting-started/errors.mdx
@@ -149,7 +149,7 @@ These codes describe tax-information errors validated by Facturapi. When a custo
 
 | Code | Description |
 | --- | --- |
-| `legal_name_mismatch` | The name, corporate name, or business name does not match the RFC in SAT records. Verify that it exactly matches the Tax Status Certificate (Constancia de Situación Fiscal). |
+| `legal_name_mismatch` | The name or business name does not match the RFC in SAT records. Verify that it exactly matches the Tax Status Certificate (Constancia de Situación Fiscal). |
 | `tax_address_zip_mismatch` | The fiscal zip code does not match the RFC in SAT records. |
 | `tax_id_not_found` | The receiver RFC does not exist in SAT's list of registered, non-cancelled RFCs. |
 | `tax_system_not_allowed_for_tax_id` | The tax regime is not allowed for the RFC in SAT records. |

--- a/website/i18n/en/docusaurus-plugin-content-docs/current/getting-started/errors.mdx
+++ b/website/i18n/en/docusaurus-plugin-content-docs/current/getting-started/errors.mdx
@@ -134,6 +134,7 @@ This list is the documented reference for public root API codes. We may add new 
 | `invalid_image_file` | The provided file is not a valid image. |
 | `invalid_json` | The request body is not valid JSON. |
 | `invalid_request` | The request is invalid. |
+| `invalid_tax_info` | The tax information is invalid. |
 | `invalid_multipart_form_data` | The multipart/form-data payload is invalid. |
 | `invalid_state_code` | The state code is invalid. |
 | `invalid_timezone` | The timezone is invalid. |
@@ -152,12 +153,6 @@ This list is the documented reference for public root API codes. We may add new 
 | `customer_has_invoices` | The customer cannot be deleted because it has associated invoices. |
 | `customer_not_found` | The customer was not found. |
 | `customer_tax_info_unavailable` | The customer tax information is not available. |
-
-### TaxInfoErrorCode
-
-| Code | Description |
-| --- | --- |
-| `invalid_tax_info` | The tax information is invalid. |
 
 ### ProductErrorCode
 

--- a/website/i18n/en/docusaurus-plugin-content-docs/current/getting-started/errors.mdx
+++ b/website/i18n/en/docusaurus-plugin-content-docs/current/getting-started/errors.mdx
@@ -55,7 +55,7 @@ Codes inside `errors[]` are detail subcodes. They explain invalid fields or exte
 
 When the request does not match the input contract, the root error uses `code: "invalid_request"`. When details are available, `errors[]` includes each invalid field with `source: "facturapi"`, `path`, `location`, and a validation subcode.
 
-Validation subcodes are documented at the end of this page as detail subcodes because they appear in `errors[].code`, not in `error.code`.
+Validation subcodes are documented at the end of this page as detail subcodes because they appear in `errors[].code`, not in the root `code`.
 
 ### External errors
 

--- a/website/i18n/en/docusaurus-plugin-content-docs/current/getting-started/errors.mdx
+++ b/website/i18n/en/docusaurus-plugin-content-docs/current/getting-started/errors.mdx
@@ -92,7 +92,7 @@ Some error responses include useful headers for programmatic handling or observa
 | `Retry-After` | Recommended seconds to wait before retrying. Included in errors with `code: "rate_limit_exceeded"`. |
 | `X-Facturapi-Log-Id` | Request correlation ID. You can keep it in your observability stack to investigate errors with support. |
 
-## Root error codes (`error.code`)
+## Root error codes (`code`)
 
 This list is the documented reference for public root API codes. We may add new codes at any time when new features or new error cases require them, but we aim to keep this page up to date so integrations have a predictable reference.
 
@@ -145,7 +145,7 @@ This list is the documented reference for public root API codes. We may add new 
 
 ### TaxInfoValidationCode
 
-These codes describe tax-information errors validated by Facturapi. When a customer or organization tax-information validation detects a single issue, it appears in `error.code`. Input validations and the customer tax-information validation endpoint return them in `errors[].code`.
+These codes describe tax-information errors validated by Facturapi. When a customer or organization tax-information validation detects a single issue, it appears in `code`. Input validations and the customer tax-information validation endpoint return them in `errors[].code`.
 
 | Code | Description |
 | --- | --- |

--- a/website/i18n/en/docusaurus-plugin-content-docs/current/getting-started/errors.mdx
+++ b/website/i18n/en/docusaurus-plugin-content-docs/current/getting-started/errors.mdx
@@ -63,18 +63,18 @@ Validation subcodes are documented at the end of this page as detail subcodes be
 
 Some operations depend on external validations or services, such as SAT or PAC. In those cases, the root `code` remains a Facturapi code, for example `invoice_stamping_validation_error`.
 
-If the external provider returns useful details, they are included in `errors[]` with the original code:
+If the external provider returns useful details that Facturapi cannot classify reliably, they are included in `errors[]` with the original code:
 
 ```json
 {
-  "message": "El RFC del receptor no se encuentra en la lista de RFC inscritos no cancelados del SAT.",
+  "message": "No se encontró el RFC [AAA010101AAA] en la Lista de Contribuyentes Obligados.",
   "status": 400,
   "code": "invoice_stamping_validation_error",
   "errors": [
     {
-      "message": "El RFC del receptor no se encuentra en la lista de RFC inscritos no cancelados del SAT.",
-      "code": "CFDI40145",
-      "source": "sat"
+      "message": "No se encontró el RFC [AAA010101AAA] en la Lista de Contribuyentes Obligados.",
+      "code": "402",
+      "source": "pac"
     }
   ],
   "ok": false

--- a/website/i18n/en/docusaurus-plugin-content-docs/current/getting-started/errors.mdx
+++ b/website/i18n/en/docusaurus-plugin-content-docs/current/getting-started/errors.mdx
@@ -38,7 +38,7 @@ The API returns errors as JSON and uses standard HTTP status codes. For programm
 | `code` | `string` | Stable root code for handling the error. |
 | `location` | `string` | Location of the data related to the error, such as `body`, `query`, `params`, or `files`. Included only when applicable. |
 | `path` | `string` | Path of the field related to the error. Included only when applicable. |
-| `errors` | `array` | Additional details. Included only when they provide useful information. |
+| `errors` | `array` | Actionable details to correct the request or understand an external response. It can include multiple items when multiple issues are detected. |
 | `errors[].message` | `string` | Human-readable message for a detail. |
 | `errors[].code` | `string` | Detail subcode. Facturapi validation errors use an input-validation or tax-information-validation subcode; external errors may use the original SAT or PAC code. |
 | `errors[].location` | `string` | Location of the data related to the detail, such as `body`, `query`, `params`, or `files`. |
@@ -49,7 +49,7 @@ The API returns errors as JSON and uses standard HTTP status codes. For programm
 
 The root `code` classifies the main result of the request and is the value you should check first when deciding how to handle an error.
 
-Codes inside `errors[]` are detail subcodes. They explain invalid fields or external responses, but they do not replace the root `code`. When `source` is `facturapi`, the subcode and message are defined by Facturapi. When `source` is external, the subcode may be the original code from the indicated system.
+The `errors[]` array appears when the response needs to explain one or more details in addition to the main outcome: for example, multiple invalid fields in the same request or reasons returned by an external provider. Its codes are detail subcodes and do not replace the root `code`. When `source` is `facturapi`, the subcode and message are defined by Facturapi. When `source` is external, the subcode may be the original code from the indicated system.
 
 ### Validation errors
 
@@ -378,9 +378,7 @@ These values appear inside `errors[]` to explain specific details of the root er
 
 ### Input validation
 
-These subcodes usually appear when the root code is `invalid_request`, but they
-may also appear in `errors[]` for other root codes when the error detail is about
-invalid fields or values.
+When a request has multiple invalid fields or values, `errors[]` includes one detail for each. These subcodes identify the problem in each detail.
 
 Interpret the subcode together with `path`, `location`, and the original request. Subcodes are intentionally generic and do not change based on the field type or endpoint flow.
 

--- a/website/i18n/en/docusaurus-plugin-content-docs/current/getting-started/errors.mdx
+++ b/website/i18n/en/docusaurus-plugin-content-docs/current/getting-started/errors.mdx
@@ -51,6 +51,8 @@ The root `code` classifies the main result of the request and is the value you s
 
 The `errors[]` array appears when the response needs to explain one or more details in addition to the main outcome: for example, multiple invalid fields in the same request or reasons returned by an external provider. Its codes are detail subcodes and do not replace the root `code`. When `source` is `facturapi`, the subcode and message are defined by Facturapi. When `source` is external, the subcode may be the original code from the indicated system.
 
+When an error uses its default root message, `message` repeats the first detail message in `errors[]`. This preserves a useful message for integrations that do not yet process structured details; for programmatic logic, always use `code`, `errors[].code`, and `path`.
+
 ### Validation errors
 
 When the request does not match the input contract, the root error uses `code: "invalid_request"`. When details are available, `errors[]` includes each invalid field with `source: "facturapi"`, `path`, `location`, and a validation subcode.
@@ -65,7 +67,7 @@ If the external provider returns useful details, they are included in `errors[]`
 
 ```json
 {
-  "message": "La factura no pasó la validación de timbrado.",
+  "message": "El RFC del receptor no se encuentra en la lista de RFC inscritos no cancelados del SAT.",
   "status": 400,
   "code": "invoice_stamping_validation_error",
   "errors": [
@@ -392,13 +394,13 @@ Interpret the subcode together with `path`, `location`, and the original request
 
 ### Tax information validation
 
-These subcodes describe tax information validations performed by Facturapi. They may appear when creating or editing a customer or organization, and in the result of validating a customer's tax information. Values outside the catalog are reported under the endpoint's validation root code; values that do not match tax records are reported under `invalid_tax_info`.
+These subcodes describe tax information validations performed by Facturapi. They may appear when creating or editing a customer or organization, in the result of validating a customer's tax information, and while stamping an invoice when a rejection reliably identifies a receiver tax-information validation. Values outside the catalog are reported under the endpoint's validation root code; values that do not match tax records are reported under `invalid_tax_info`.
 
 | Code | Description |
 | --- | --- |
 | `legal_name_mismatch` | The legal name does not match the RFC in SAT records. |
 | `tax_address_zip_mismatch` | The fiscal zip code does not match the RFC in SAT records. |
-| `tax_id_not_found` | The RFC was not found in SAT records. |
+| `tax_id_not_found` | The receiver RFC does not exist in SAT's list of registered, non-cancelled RFCs. |
 | `tax_system_not_allowed_for_tax_id` | The tax regime is not allowed for the RFC in SAT records. |
 | `tax_system_not_in_catalog` | The tax regime does not belong to the SAT catalog. |
 

--- a/website/openapi_v2.en.yaml
+++ b/website/openapi_v2.en.yaml
@@ -2579,18 +2579,31 @@ paths:
                     example: true
                   errors:
                     type: array
-                    description: List of errors found in the validation
+                    description: Tax information validation details. They are only included when `is_valid` is `false`.
                     items:
                       type: object
+                      required:
+                        - source
+                        - code
+                        - message
                       properties:
+                        source:
+                          type: string
+                          enum: [facturapi]
+                          description: Indicates that Facturapi generated the validation detail.
+                          example: facturapi
+                        code:
+                          type: string
+                          description: Stable validation detail code.
+                          example: tax_system_not_allowed_for_tax_id
                         path:
                           type: string
-                          description: Path to the field with the error
+                          description: Path to the field whose tax information is invalid.
                           example: tax_system
                         message:
                           type: string
-                          description: Error message
-                          example: El RégimenFiscal no coincide con el registrado para el RFC en la lista de contribuyentes obligados del SAT.
+                          description: Descriptive validation detail message.
+                          example: El régimen fiscal no está permitido para el RFC en los registros del SAT.
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -11042,7 +11055,7 @@ components:
           schema:
             $ref: "#/components/schemas/GenericError"
           example:
-            message: Too many requests. Please retry shortly.
+            message: Se excedió el límite de solicitudes.
             status: 429
             ok: false
             code: rate_limit_exceeded
@@ -11368,6 +11381,11 @@ components:
           description: Upper inclusive limit of the date range to request.
     GenericError:
       type: object
+      required:
+        - message
+        - status
+        - ok
+        - code
       properties:
         message:
           type: string
@@ -11401,18 +11419,22 @@ components:
           description: Optional path to the field related to the error.
         errors:
           type: array
-          description: Additional error details. Included only when there are validation errors or relevant external details.
+          description: Additional error details. Included only when they provide useful information.
           items:
             $ref: "#/components/schemas/ErrorDetail"
     ErrorDetail:
       type: object
+      required:
+        - message
+        - code
+        - source
       properties:
         message:
           type: string
           description: Human-readable detail message.
         code:
           type: string
-          description: Detail subcode. Validation errors use codes such as `required` or `invalid_type`; external errors may contain the provider's original code.
+          description: Detail subcode. Facturapi validation errors use codes such as `required`, `invalid_type`, or `tax_id_not_found`; external errors may contain the provider's original code.
           example: required
         location:
           type: string

--- a/website/openapi_v2.en.yaml
+++ b/website/openapi_v2.en.yaml
@@ -2579,7 +2579,7 @@ paths:
                     example: true
                   errors:
                     type: array
-                    description: Tax information validation details. They are only included when `is_valid` is `false`.
+                    description: Tax information validation details. This is an empty array when `is_valid` is `true`.
                     items:
                       type: object
                       required:

--- a/website/openapi_v2.en.yaml
+++ b/website/openapi_v2.en.yaml
@@ -5569,11 +5569,7 @@ paths:
         "401":
           $ref: "#/components/responses/Unauthenticated"
         "404":
-          description: No eligible receipts found for the provided keys
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ToInvoiceNotFoundResponse"
+          $ref: "#/components/responses/NotFound"
         "500":
           $ref: "#/components/responses/UnexpectedError"
   /receipts/to-invoice/preview:
@@ -11432,7 +11428,11 @@ components:
           description: Optional path to the field related to this detail.
         source:
           type: string
-          description: Optional source for external details, for example `sat`.
+          description: Source of the detail.
+          enum:
+            - facturapi
+            - sat
+            - pac
     IssuingType:
       type: string
       description: Indicates whether the invoice was issued by your organization or received from a third party.
@@ -16250,26 +16250,6 @@ components:
     ToInvoiceSummary:
       type: object
       description: Summary object returned when `dry_run=true`.
-    ToInvoiceNotFoundResponse:
-      type: object
-      required:
-        - invoice
-        - summary
-        - missingKeys
-      properties:
-        invoice:
-          nullable: true
-          type: object
-          description: Always `null` when no invoice was created.
-        summary:
-          nullable: true
-          type: object
-          description: Summary preview when available.
-        missingKeys:
-          type: array
-          description: Receipt keys that were not found or not eligible.
-          items:
-            type: string
     Retention:
       title: Retention object
       allOf:

--- a/website/openapi_v2.en.yaml
+++ b/website/openapi_v2.en.yaml
@@ -2572,6 +2572,9 @@ paths:
             application/json:
               schema:
                 type: object
+                required:
+                  - is_valid
+                  - errors
                 properties:
                   is_valid:
                     type: boolean

--- a/website/openapi_v2.yaml
+++ b/website/openapi_v2.yaml
@@ -2807,18 +2807,31 @@ paths:
                     example: true
                   errors:
                     type: array
-                    description: Lista de errores encontrados
+                    description: Detalles de validación fiscal. Solo se incluyen cuando `is_valid` es `false`.
                     items:
                       type: object
+                      required:
+                        - source
+                        - code
+                        - message
                       properties:
+                        source:
+                          type: string
+                          enum: [facturapi]
+                          description: Indica que Facturapi generó el detalle de validación.
+                          example: facturapi
+                        code:
+                          type: string
+                          description: Código estable del detalle de validación.
+                          example: tax_system_not_allowed_for_tax_id
                         path:
                           type: string
-                          description: Nombre del campo que no coincide con los registros del SAT
+                          description: Ruta del campo cuya información fiscal no es válida.
                           example: tax_system
                         message:
                           type: string
-                          description: Mensaje de error
-                          example: El RégimenFiscal no coincide con el registrado para el RFC en la lista de contribuyentes obligados del SAT.
+                          description: Mensaje descriptivo del detalle de validación.
+                          example: El régimen fiscal no está permitido para el RFC en los registros del SAT.
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -11247,7 +11260,7 @@ components:
           schema:
             $ref: "#/components/schemas/GenericError"
           example:
-            message: Too many requests. Please retry shortly.
+            message: Se excedió el límite de solicitudes.
             status: 429
             ok: false
             code: rate_limit_exceeded
@@ -11603,6 +11616,11 @@ components:
           description: Límite superior inclusivo del rango de fechas a solicitar.
     GenericError:
       type: object
+      required:
+        - message
+        - status
+        - ok
+        - code
       properties:
         message:
           type: string
@@ -11636,18 +11654,22 @@ components:
           description: Ruta opcional del campo relacionado con el error.
         errors:
           type: array
-          description: Detalles adicionales del error. Sólo se incluye cuando hay errores de validación o detalles externos relevantes.
+          description: Detalles adicionales del error. Sólo se incluye cuando aporta información útil.
           items:
             $ref: "#/components/schemas/ErrorDetail"
     ErrorDetail:
       type: object
+      required:
+        - message
+        - code
+        - source
       properties:
         message:
           type: string
           description: Mensaje legible del detalle.
         code:
           type: string
-          description: Subcódigo del detalle. En validaciones usa códigos como `required` o `invalid_type`; en errores externos puede contener el código original del proveedor.
+          description: Subcódigo del detalle. En validaciones de Facturapi usa códigos como `required`, `invalid_type` o `tax_id_not_found`; en errores externos puede contener el código original del proveedor.
           example: required
         location:
           type: string

--- a/website/openapi_v2.yaml
+++ b/website/openapi_v2.yaml
@@ -5786,11 +5786,7 @@ paths:
         "401":
           $ref: "#/components/responses/Unauthenticated"
         "404":
-          description: No se encontraron recibos elegibles para las keys enviadas
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ToInvoiceNotFoundResponse"
+          $ref: "#/components/responses/NotFound"
         "500":
           $ref: "#/components/responses/UnexpectedError"
   /receipts/to-invoice/preview:
@@ -11667,7 +11663,11 @@ components:
           description: Ruta opcional del campo relacionado con este detalle.
         source:
           type: string
-          description: Fuente opcional para detalles externos, por ejemplo `sat`.
+          description: Fuente del detalle.
+          enum:
+            - facturapi
+            - sat
+            - pac
     IssuingType:
       type: string
       description: Indica si la factura fue emitida por tu organización o recibida de un tercero.
@@ -16503,26 +16503,6 @@ components:
     ToInvoiceSummary:
       type: object
       description: Objeto resumen que regresa cuando `dry_run=true`.
-    ToInvoiceNotFoundResponse:
-      type: object
-      required:
-        - invoice
-        - summary
-        - missingKeys
-      properties:
-        invoice:
-          nullable: true
-          type: object
-          description: Siempre `null` cuando no se creó la factura.
-        summary:
-          nullable: true
-          type: object
-          description: Resumen de vista previa cuando está disponible.
-        missingKeys:
-          type: array
-          description: Keys de recibos no encontradas o no elegibles.
-          items:
-            type: string
     Retention:
       title: Objeto Retention
       allOf:

--- a/website/openapi_v2.yaml
+++ b/website/openapi_v2.yaml
@@ -2800,6 +2800,9 @@ paths:
             application/json:
               schema:
                 type: object
+                required:
+                  - is_valid
+                  - errors
                 properties:
                   is_valid:
                     type: boolean

--- a/website/openapi_v2.yaml
+++ b/website/openapi_v2.yaml
@@ -2807,7 +2807,7 @@ paths:
                     example: true
                   errors:
                     type: array
-                    description: Detalles de validación fiscal. Solo se incluyen cuando `is_valid` es `false`.
+                    description: Detalles de validación fiscal. Es un array vacío cuando `is_valid` es `true`.
                     items:
                       type: object
                       required:


### PR DESCRIPTION
## Objetivo

Alinear la documentación pública con el contrato actual de errores de API, especialmente los detalles de certificados, validación fiscal y facturación de recibos.

## Cambios

- Actualiza la guía de manejo de errores en español e inglés.
- Documenta que `message` es humano, que hoy se devuelve en español y que puede cambiar por claridad o futura localización.
- Documenta que `code` y `errors[].code` son los campos estables para lógica programática.
- Lista códigos raíz públicos por categoría y aclara que pueden agregarse nuevos códigos conforme evolucione la API.
- Distingue los códigos fiscales propios: aparecen como `error.code` para una validación fiscal única y como `errors[].code` en validaciones de entrada o en el endpoint de validación fiscal.
- Documenta que los detalles SAT/PAC de timbrado se preservan con `errors[].source`.
- Documenta `receipt_keys_not_found` y el uso de `errors[].path = "keys.N"` cuando sólo faltan algunas keys.
- Alinea OpenAPI para `/receipts/to-invoice` con el error estándar `NotFound` y elimina la respuesta legacy `ToInvoiceNotFoundResponse`.

## Validación

- `pnpm --dir website typecheck`
- Validación de parseo YAML de `website/openapi_v2.yaml` y `website/i18n/en/docusaurus-plugin-content-docs/current/openapi_v2.yaml`
- `git diff --check`