### PR TITLE
Documenta código de nombre fiscal no encontrado

### DIFF
--- a/website/docs/getting-started/errors.mdx
+++ b/website/docs/getting-started/errors.mdx
@@ -149,6 +149,7 @@ Estos códigos describen errores de información fiscal validados por Facturapi.
 
 | Código | Descripción |
 | --- | --- |
+| `legal_name_not_found` | El nombre o razón social no se encuentra en los registros del SAT. Verifica que coincida exactamente con la Constancia de Situación Fiscal. |
 | `legal_name_mismatch` | El nombre o razón social no corresponde al RFC en los registros del SAT. Verifica que coincida exactamente con la Constancia de Situación Fiscal. |
 | `tax_address_zip_mismatch` | El código postal fiscal no corresponde al RFC en los registros del SAT. |
 | `tax_id_not_found` | Este RFC del receptor no existe en la lista de RFC inscritos no cancelados del SAT. |

--- a/website/i18n/en/docusaurus-plugin-content-docs/current/getting-started/errors.mdx
+++ b/website/i18n/en/docusaurus-plugin-content-docs/current/getting-started/errors.mdx
@@ -149,6 +149,7 @@ These codes describe tax-information errors validated by Facturapi. When a custo
 
 | Code | Description |
 | --- | --- |
+| `legal_name_not_found` | The name or business name is not found in SAT records. Verify that it exactly matches the Tax Status Certificate (Constancia de Situación Fiscal). |
 | `legal_name_mismatch` | The name or business name does not match the RFC in SAT records. Verify that it exactly matches the Tax Status Certificate (Constancia de Situación Fiscal). |
 | `tax_address_zip_mismatch` | The fiscal zip code does not match the RFC in SAT records. |
 | `tax_id_not_found` | The receiver RFC does not exist in SAT's list of registered, non-cancelled RFCs. |


### PR DESCRIPTION
## Objetivo

Documenta el nuevo código público legal_name_not_found para que la referencia de errores permanezca alineada con la normalización del servidor.

## Cambios

- Agrega el código y su mensaje en español e inglés.
- Distingue legal_name_not_found de legal_name_mismatch.