### PR TITLE
Aclara recomendación para código postal fiscal

### DIFF
--- a/website/docs/getting-started/errors.mdx
+++ b/website/docs/getting-started/errors.mdx
@@ -150,7 +150,7 @@ Estos códigos describen errores de información fiscal validados por Facturapi.
 | Código | Descripción |
 | --- | --- |
 | `legal_name_mismatch` | El nombre o razón social no corresponde al RFC en los registros del SAT. Verifica que coincida exactamente con la Constancia de Situación Fiscal. |
-| `tax_address_zip_mismatch` | El código postal fiscal no corresponde al RFC en los registros del SAT. |
+| `tax_address_zip_mismatch` | El código postal fiscal no corresponde al RFC en los registros del SAT. Verifica que coincida con la Constancia de Situación Fiscal. |
 | `tax_id_not_found` | Este RFC del receptor no existe en la lista de RFC inscritos no cancelados del SAT. |
 | `tax_system_not_allowed_for_tax_id` | El régimen fiscal no está permitido para el RFC en los registros del SAT. |
 | `tax_system_not_in_catalog` | El régimen fiscal no pertenece al catálogo del SAT. |

--- a/website/i18n/en/docusaurus-plugin-content-docs/current/getting-started/errors.mdx
+++ b/website/i18n/en/docusaurus-plugin-content-docs/current/getting-started/errors.mdx
@@ -150,7 +150,7 @@ These codes describe tax-information errors validated by Facturapi. When a custo
 | Code | Description |
 | --- | --- |
 | `legal_name_mismatch` | The name or business name does not match the RFC in SAT records. Verify that it exactly matches the Tax Status Certificate (Constancia de Situación Fiscal). |
-| `tax_address_zip_mismatch` | The fiscal zip code does not match the RFC in SAT records. |
+| `tax_address_zip_mismatch` | The fiscal zip code does not match the RFC in SAT records. Verify that it matches the Tax Status Certificate (Constancia de Situación Fiscal). |
 | `tax_id_not_found` | The receiver RFC does not exist in SAT's list of registered, non-cancelled RFCs. |
 | `tax_system_not_allowed_for_tax_id` | The tax regime is not allowed for the RFC in SAT records. |
 | `tax_system_not_in_catalog` | The tax regime does not belong to the SAT catalog. |


### PR DESCRIPTION
## Objetivo

Mantiene la referencia pública alineada con el mensaje de tax_address_zip_mismatch de la API.

## Cambio

- Indica que el código postal fiscal debe verificarse contra la Constancia de Situación Fiscal, en español e inglés.