### PR TITLE
Documenta cuentas prediales como arreglos

### DIFF
--- a/website/openapi_v2.en.yaml
+++ b/website/openapi_v2.en.yaml
@@ -11875,9 +11875,11 @@ components:
                 - zip
             - $ref: "#/components/schemas/ThirdParty"
         property_tax_account:
-          type: string
-          description: Bank account number for property tax.
-          example: "0102030405"
+          type: array
+          description: Property tax account numbers.
+          items:
+            type: string
+          example: ["0102030405"]
     LineItemEgresoInput:
       title: LineItem
       required:

--- a/website/openapi_v2.yaml
+++ b/website/openapi_v2.yaml
@@ -12093,9 +12093,11 @@ components:
                 - zip
             - $ref: "#/components/schemas/ThirdParty"
         property_tax_account:
-          type: string
-          description: Número de cuenta para el impuesto predial.
-          example: "0102030405"
+          type: array
+          description: Números de cuenta para el impuesto predial.
+          items:
+            type: string
+          example: ["0102030405"]
     LineItemEgresoInput:
       title: LineItem
       required:


### PR DESCRIPTION
## Objetivo

Alinea OpenAPI V2 con el contrato implementado desde 2025: property_tax_account es un arreglo de cuentas prediales.

## Cambio

- Documenta property_tax_account como string[] en español e inglés.
- No documenta la tolerancia legacy que todavía acepta un string en el servidor.