### PR TITLE
Document cursor pagination and capped totals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@
 ### Paginación por cursores (`pagination=cursor`)
 
 - Nuevo modo de paginación opt-in `pagination=cursor`, **recomendado** para
-  listas grandes: no ejecuta conteos exactos sobre la colección, por lo que es
-  más rápido que la paginación por páginas.
+  listas grandes: recorre todos los resultados sin el tope de 30 páginas del
+  modo `page`, con páginas estables aunque cambien los datos.
 - Nuevos parámetros `after` y `before` para navegar entre páginas de forma
   secuencial. Cada búsqueda regresa `previous_cursor` y `next_cursor`.
 - Nuevo campo `totals_are_capped` en las respuestas de búsqueda de ambos modos:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+## Unreleased
+
+### Paginación por cursores (`pagination=cursor`)
+
+- Nuevo modo de paginación opt-in `pagination=cursor`, **recomendado** para
+  listas grandes: no ejecuta conteos exactos sobre la colección, por lo que es
+  más rápido que la paginación por páginas.
+- Nuevos parámetros `after` y `before` para navegar entre páginas de forma
+  secuencial. Cada búsqueda regresa `previous_cursor` y `next_cursor`.
+- Nuevo campo `totals_are_capped` en las respuestas de búsqueda de ambos modos:
+  cuando hay más de 3,000 resultados, `total_results` regresa `3000` y
+  `totals_are_capped` es `true` ("más de 3,000").
+- La paginación por páginas (`pagination=page`, el modo por defecto) queda
+  limitada a 30 páginas.

--- a/website/docs/guides/pagination.mdx
+++ b/website/docs/guides/pagination.mdx
@@ -1,0 +1,142 @@
+---
+sidebar_position: 11
+---
+
+# Paginación
+
+Todos los listados de la API devuelven resultados paginados. Facturapi ofrece dos
+modos de paginación que puedes elegir con el parámetro `pagination`:
+
+- **`pagination=page`** — el modo clásico, por **páginas numeradas**. Es el
+  comportamiento por defecto cuando no se envía `pagination`.
+- **`pagination=cursor`** — el modo recomendado, por **cursores**. Es más rápido
+  porque no ejecuta conteos exactos sobre toda la colección y está pensado para
+  recorrer listas grandes de forma secuencial.
+
+## ¿Qué modo usar?
+
+| | `pagination=page` | `pagination=cursor` |
+| --- | --- | --- |
+| Navegación | Saltar a una página específica (`page=3`) | Secuencial: siguiente / anterior |
+| Total de resultados | Conteo exacto (hasta 3,000) | Informativo (conteo acotado a 3,000) |
+| Rendimiento | Ejecuta un conteo por búsqueda | Más rápido, sin conteos exactos |
+| Límites | Máximo 30 páginas | Sin límite de páginas |
+| Uso recomendado | Compatibilidad, interfaces con saltos de página | Listas grandes, iteración, exportaciones |
+
+Para la mayoría de los casos, y en particular para listas grandes, te recomendamos
+usar `pagination=cursor`.
+
+## Parámetros comunes
+
+| Parámetro | Tipo | Descripción |
+| --- | --- | --- |
+| `limit` | `integer` | Cantidad máxima de resultados a regresar, del 1 al 100. |
+| `pagination` | `string` | `page` (por defecto) o `cursor`. |
+
+Los parámetros `page`, `after` y `before` dependen del modo elegido y son
+**mutuamente excluyentes** entre modos:
+
+- `pagination=page` acepta `page`, pero no `after` ni `before`.
+- `pagination=cursor` acepta `after` o `before`, pero no `page`.
+
+Enviar `after` y `before` al mismo tiempo devuelve un error.
+
+## Paginación por páginas (`pagination=page`)
+
+Es el modo por defecto. Además de `limit`, acepta:
+
+| Parámetro | Descripción |
+| --- | --- |
+| `page` | Número de página a regresar, empezando desde 1. La página máxima es 30. |
+
+Respuesta:
+
+```json
+{
+  "data": [ ... ],
+  "page": 1,
+  "total_pages": 3,
+  "total_results": 250,
+  "totals_are_capped": false
+}
+```
+
+## Paginación por cursores (`pagination=cursor`)
+
+En lugar de un número de página, cada respuesta regresa dos cursores que te
+permiten avanzar o retroceder sobre los resultados:
+
+| Parámetro | Descripción |
+| --- | --- |
+| `after` | Devuelve los resultados posteriores al cursor indicado. |
+| `before` | Devuelve los resultados anteriores al cursor indicado. |
+
+Respuesta:
+
+```json
+{
+  "data": [ ... ],
+  "previous_cursor": null,
+  "next_cursor": "d176717f4000000.i65a8282775d4e9263da48115",
+  "total_results": 250,
+  "totals_are_capped": false
+}
+```
+
+### Navegar entre páginas
+
+1. **Primera página:** se obtiene sin enviar `after` ni `before`.
+   `previous_cursor` regresa `null`, indicando que no hay páginas anteriores.
+2. **Página siguiente:** envía `after` con el valor de `next_cursor` de la
+   respuesta anterior.
+3. **Página anterior:** envía `before` con el valor de `previous_cursor` de la
+   respuesta anterior.
+
+La presencia de `previous_cursor` y `next_cursor` es la única fuente de verdad
+para saber si hay más resultados: si `next_cursor` es `null`, llegaste al final
+de la lista; si `previous_cursor` es `null`, estás en la primera página.
+
+```bash
+# Primera página
+curl "https://www.facturapi.io/v2/invoices?pagination=cursor&limit=10" \
+  -G \
+  -H "Authorization: Bearer sk_test_API_KEY"
+
+# Página siguiente (usa next_cursor de la respuesta anterior)
+curl "https://www.facturapi.io/v2/invoices?pagination=cursor&limit=10&after=NEXT_CURSOR" \
+  -G \
+  -H "Authorization: Bearer sk_test_API_KEY"
+
+# Página anterior (usa previous_cursor de la respuesta anterior)
+curl "https://www.facturapi.io/v2/invoices?pagination=cursor&limit=10&before=PREVIOUS_CURSOR" \
+  -G \
+  -H "Authorization: Bearer sk_test_API_KEY"
+```
+
+Los cursores son tokens opacos y específicos de la búsqueda que los generó: no
+los combines con otra búsqueda ni los compartas entre distintas consultas.
+Usarlos con una búsqueda diferente puede regresar resultados inesperados.
+
+## Totales y límite de 3,000
+
+Ambos modos regresan `total_results` con el número de elementos que coinciden con
+la búsqueda, **con un tope de 3,000**:
+
+- Si hay 3,000 o menos resultados, `total_results` es exacto y
+  `totals_are_capped` es `false`.
+- Si hay más de 3,000, `total_results` regresa `3000` y `totals_are_capped` es
+  `true`, indicando que el total real es "más de 3,000".
+
+```json
+{
+  "data": [ ... ],
+  "previous_cursor": "d176717f4000000.i65a8282775d4e9263da48115",
+  "next_cursor": null,
+  "total_results": 3000,
+  "totals_are_capped": true
+}
+```
+
+En el modo `pagination=cursor`, `total_results` es informativo: el total se
+calcula con un conteo acotado a 3,000 en lugar de un conteo exacto sobre toda
+la colección, por lo que es más rápida incluso con listas muy grandes.

--- a/website/docs/guides/pagination.mdx
+++ b/website/docs/guides/pagination.mdx
@@ -89,6 +89,10 @@ Respuesta:
 }
 ```
 
+`total_results` y `totals_are_capped` se incluyen únicamente en la **primera
+página** de la búsqueda (cuando no se envían `after` ni `before`): el total no
+cambia entre páginas, así que las siguientes solo regresan `data` y los cursores.
+
 ### Navegar entre páginas
 
 1. **Primera página:** se obtiene sin enviar `after` ni `before`.

--- a/website/docs/guides/pagination.mdx
+++ b/website/docs/guides/pagination.mdx
@@ -9,18 +9,17 @@ modos de paginación que puedes elegir con el parámetro `pagination`:
 
 - **`pagination=page`** — el modo clásico, por **páginas numeradas**. Es el
   comportamiento por defecto cuando no se envía `pagination`.
-- **`pagination=cursor`** — el modo recomendado, por **cursores**. Es más rápido
-  porque no ejecuta conteos exactos sobre toda la colección y está pensado para
-  recorrer listas grandes de forma secuencial.
+- **`pagination=cursor`** — el modo recomendado, por **cursores**. Recorre los
+  resultados de forma secuencial, sin el tope de 30 páginas del modo `page`, y
+  con páginas estables aunque cambien los datos.
 
 ## ¿Qué modo usar?
 
 | | `pagination=page` | `pagination=cursor` |
 | --- | --- | --- |
 | Navegación | Saltar a una página específica (`page=3`) | Secuencial: siguiente / anterior |
-| Total de resultados | Conteo exacto (hasta 3,000) | Informativo (conteo acotado a 3,000) |
-| Rendimiento | Ejecuta un conteo por búsqueda | Más rápido, sin conteos exactos |
-| Límites | Máximo 30 páginas | Sin límite de páginas |
+| Alcance | Hasta 3,000 resultados (30 páginas × 100) | Todos los resultados de la búsqueda |
+| Estabilidad | Las páginas se corren si cambian los datos | Páginas estables (basadas en posición) |
 | Uso recomendado | Compatibilidad, interfaces con saltos de página | Listas grandes, iteración, exportaciones |
 
 Para la mayoría de los casos, y en particular para listas grandes, te recomendamos
@@ -144,6 +143,7 @@ la búsqueda, **con un tope de 3,000**:
 }
 ```
 
-En el modo `pagination=cursor`, `total_results` es informativo: el total se
-calcula con un conteo acotado a 3,000 en lugar de un conteo exacto sobre toda
-la colección, por lo que es más rápida incluso con listas muy grandes.
+En ambos modos `total_results` es informativo: el conteo se acota a 3,000 y no
+recorre toda la colección. La ventaja práctica de `pagination=cursor` no es la
+velocidad del conteo (ambos modos lo acotan), sino su **alcance** y la
+**estabilidad** de las páginas.

--- a/website/docs/guides/pagination.mdx
+++ b/website/docs/guides/pagination.mdx
@@ -26,6 +26,13 @@ modos de paginación que puedes elegir con el parámetro `pagination`:
 Para la mayoría de los casos, y en particular para listas grandes, te recomendamos
 usar `pagination=cursor`.
 
+La diferencia práctica más importante entre ambos modos es el **alcance**:
+`pagination=page` solo permite acceder a los primeros 3,000 resultados
+(30 páginas × 100 por página), mientras que `pagination=cursor` puede recorrer
+**todos** los resultados de la búsqueda, incluso cuando `total_results` está
+capeado a 3,000. Si necesitas exportar o procesar más de 3,000 resultados, usa
+`pagination=cursor`.
+
 ## Parámetros comunes
 
 | Parámetro | Tipo | Descripción |

--- a/website/docs/guides/pagination.mdx
+++ b/website/docs/guides/pagination.mdx
@@ -51,6 +51,20 @@ Los parámetros `page`, `after` y `before` dependen del modo elegido y son
 
 Enviar `after` y `before` al mismo tiempo devuelve un error.
 
+### Formato de los filtros en la URL
+
+Los filtros viajan en el query string con dos formatos, los mismos que emiten
+los SDK oficiales:
+
+- **Objetos y rangos**: notación de corchetes, por ejemplo
+  `date[gte]=2026-01-01&date[lt]=2026-02-01` (el estilo `deepObject`).
+- **Arreglos**: la clave se repite, por ejemplo `status=valid&status=canceled`
+  (`form` con `explode`).
+
+La API también acepta las variantes más comunes de arreglos
+(`status[]=valid&status[]=canceled` y `status[0]=valid&status[1]=canceled`), de
+modo que las integraciones existentes siguen funcionando.
+
 ## Paginación por páginas (`pagination=page`)
 
 Es el modo por defecto. Además de `limit`, acepta:

--- a/website/docs/guides/pagination.mdx
+++ b/website/docs/guides/pagination.mdx
@@ -14,7 +14,7 @@ puedes elegir con el parámetro `pagination`:
 - **`pagination=page`** — el modo clásico, por **páginas numeradas**. Es el
   comportamiento por defecto cuando no se envía `pagination`.
 - **`pagination=cursor`** — el modo recomendado, por **cursores**. Recorre los
-  resultados de forma secuencial, sin el tope de 30 páginas del modo `page`, y
+  resultados de forma secuencial, sin el tope de 3,000 resultados del modo `page`, y
   con páginas estables aunque cambien los datos.
 
 ## ¿Qué modo usar?

--- a/website/docs/guides/pagination.mdx
+++ b/website/docs/guides/pagination.mdx
@@ -5,23 +5,16 @@ sidebar_position: 11
 # Paginación
 
 Los listados de clientes (`/customers`), facturas (`/invoices`), recibos
-(`/receipts`), productos (`/products`) y retenciones (`/retentions`), así como
-las búsquedas de catálogo (`/catalogs/...`), devuelven resultados paginados. En
-estos endpoints de búsqueda, Facturapi ofrece dos modos de paginación que puedes
-elegir con el parámetro `pagination`:
+(`/receipts`), productos (`/products`), retenciones (`/retentions`) y webhooks
+(`/webhooks`), así como las búsquedas de catálogo (`/catalogs/...`), devuelven
+resultados paginados. En estos endpoints, Facturapi ofrece dos modos de
+paginación que puedes elegir con el parámetro `pagination`:
 
 - **`pagination=page`** — el modo clásico, por **páginas numeradas**. Es el
   comportamiento por defecto cuando no se envía `pagination`.
 - **`pagination=cursor`** — el modo recomendado, por **cursores**. Recorre los
   resultados de forma secuencial, sin el tope de 30 páginas del modo `page`, y
   con páginas estables aunque cambien los datos.
-
-:::note
-El listado de webhooks (`GET /webhooks`) también devuelve resultados paginados,
-pero no forma parte de las búsquedas que soportan cursores: solo acepta los
-parámetros `page` y `limit` del modo `pagination=page`. No envíes
-`pagination=cursor`, `after` ni `before` a ese endpoint.
-:::
 
 ## ¿Qué modo usar?
 
@@ -47,7 +40,7 @@ capeado a 3,000. Si necesitas exportar o procesar más de 3,000 resultados, usa
 | Parámetro | Tipo | Descripción |
 | --- | --- | --- |
 | `limit` | `integer` | Cantidad máxima de resultados a regresar, del 1 al 100. |
-| `pagination` | `string` | `page` (por defecto) o `cursor`. No disponible en el listado de webhooks. |
+| `pagination` | `string` | `page` (por defecto) o `cursor`. |
 
 Los parámetros `page`, `after` y `before` dependen del modo elegido y son
 **mutuamente excluyentes** entre modos:

--- a/website/docs/guides/pagination.mdx
+++ b/website/docs/guides/pagination.mdx
@@ -4,14 +4,24 @@ sidebar_position: 11
 
 # Paginación
 
-Todos los listados de la API devuelven resultados paginados. Facturapi ofrece dos
-modos de paginación que puedes elegir con el parámetro `pagination`:
+Los listados de clientes (`/customers`), facturas (`/invoices`), recibos
+(`/receipts`), productos (`/products`) y retenciones (`/retentions`), así como
+las búsquedas de catálogo (`/catalogs/...`), devuelven resultados paginados. En
+estos endpoints de búsqueda, Facturapi ofrece dos modos de paginación que puedes
+elegir con el parámetro `pagination`:
 
 - **`pagination=page`** — el modo clásico, por **páginas numeradas**. Es el
   comportamiento por defecto cuando no se envía `pagination`.
 - **`pagination=cursor`** — el modo recomendado, por **cursores**. Recorre los
   resultados de forma secuencial, sin el tope de 30 páginas del modo `page`, y
   con páginas estables aunque cambien los datos.
+
+:::note
+El listado de webhooks (`GET /webhooks`) también devuelve resultados paginados,
+pero no forma parte de las búsquedas que soportan cursores: solo acepta los
+parámetros `page` y `limit` del modo `pagination=page`. No envíes
+`pagination=cursor`, `after` ni `before` a ese endpoint.
+:::
 
 ## ¿Qué modo usar?
 
@@ -37,7 +47,7 @@ capeado a 3,000. Si necesitas exportar o procesar más de 3,000 resultados, usa
 | Parámetro | Tipo | Descripción |
 | --- | --- | --- |
 | `limit` | `integer` | Cantidad máxima de resultados a regresar, del 1 al 100. |
-| `pagination` | `string` | `page` (por defecto) o `cursor`. |
+| `pagination` | `string` | `page` (por defecto) o `cursor`. No disponible en el listado de webhooks. |
 
 Los parámetros `page`, `after` y `before` dependen del modo elegido y son
 **mutuamente excluyentes** entre modos:

--- a/website/docs/guides/pagination.mdx
+++ b/website/docs/guides/pagination.mdx
@@ -5,11 +5,11 @@ sidebar_position: 11
 # Paginación
 
 Los listados de clientes (`/customers`), facturas (`/invoices`), recibos
-(`/receipts`), productos (`/products`), retenciones (`/retentions`),
-organizaciones (`/organizations`) y webhooks (`/webhooks`), así como las
-búsquedas de catálogo (`/catalogs/...`), devuelven
-resultados paginados. En estos endpoints, Facturapi ofrece dos modos de
-paginación que puedes elegir con el parámetro `pagination`:
+(`/receipts`), productos (`/products`), proveedores (`/suppliers`), retenciones
+(`/retentions`), organizaciones (`/organizations`) y webhooks (`/webhooks`),
+así como las búsquedas de catálogo (`/catalogs/...`), devuelven resultados
+paginados. En estos endpoints, Facturapi ofrece dos modos de paginación que
+puedes elegir con el parámetro `pagination`:
 
 - **`pagination=page`** — el modo clásico, por **páginas numeradas**. Es el
   comportamiento por defecto cuando no se envía `pagination`.
@@ -71,12 +71,13 @@ Es el modo por defecto. Además de `limit`, acepta:
 
 | Parámetro | Descripción |
 | --- | --- |
-| `page` | Número de página a regresar, empezando desde 1. La página máxima es 30. |
+| `page` | Número de página a regresar, empezando desde 1. El máximo depende del tope de 3,000 resultados (ver más abajo): con el `limit` por defecto de 100, la página máxima es 30. |
 
 En los listados (`/customers`, `/invoices`, …) `page` es el parámetro compartido,
-que va del 1 al 30. Las **búsquedas de catálogo** (`/catalogs/...`) declaran
-`page` y `limit` de forma propia: ahí `page` acepta `0` (equivalente a la primera
-página) además de `1`–`30`, y `limit` conserva el rango del 1 al 100.
+que empieza en 1. Las **búsquedas de catálogo** (`/catalogs/...`) aceptan los
+mismos parámetros de paginación, con `limit` del 1 al 100. El máximo de `page` no
+es fijo: sale del tope de 3,000 resultados (con el `limit` por defecto de 100 son
+30 páginas).
 
 Respuesta:
 

--- a/website/docs/guides/pagination.mdx
+++ b/website/docs/guides/pagination.mdx
@@ -119,17 +119,17 @@ de la lista; si `previous_cursor` es `null`, estás en la primera página.
 # Primera página
 curl "https://www.facturapi.io/v2/invoices?pagination=cursor&limit=10" \
   -G \
-  -u 'sk_test_API_KEY:'
+  -H "Authorization: Bearer sk_test_API_KEY"
 
 # Página siguiente (usa next_cursor de la respuesta anterior)
 curl "https://www.facturapi.io/v2/invoices?pagination=cursor&limit=10&after=NEXT_CURSOR" \
   -G \
-  -u 'sk_test_API_KEY:'
+  -H "Authorization: Bearer sk_test_API_KEY"
 
 # Página anterior (usa previous_cursor de la respuesta anterior)
 curl "https://www.facturapi.io/v2/invoices?pagination=cursor&limit=10&before=PREVIOUS_CURSOR" \
   -G \
-  -u 'sk_test_API_KEY:'
+  -H "Authorization: Bearer sk_test_API_KEY"
 ```
 
 Los cursores son tokens opacos y específicos de la búsqueda que los generó: no

--- a/website/docs/guides/pagination.mdx
+++ b/website/docs/guides/pagination.mdx
@@ -5,8 +5,9 @@ sidebar_position: 11
 # Paginación
 
 Los listados de clientes (`/customers`), facturas (`/invoices`), recibos
-(`/receipts`), productos (`/products`), retenciones (`/retentions`) y webhooks
-(`/webhooks`), así como las búsquedas de catálogo (`/catalogs/...`), devuelven
+(`/receipts`), productos (`/products`), retenciones (`/retentions`),
+organizaciones (`/organizations`) y webhooks (`/webhooks`), así como las
+búsquedas de catálogo (`/catalogs/...`), devuelven
 resultados paginados. En estos endpoints, Facturapi ofrece dos modos de
 paginación que puedes elegir con el parámetro `pagination`:
 

--- a/website/docs/guides/pagination.mdx
+++ b/website/docs/guides/pagination.mdx
@@ -149,8 +149,8 @@ la búsqueda, **con un tope de 3,000**:
 ```json
 {
   "data": [ ... ],
-  "previous_cursor": "d176717f4000000.i65a8282775d4e9263da48115",
-  "next_cursor": null,
+  "previous_cursor": null,
+  "next_cursor": "d176717f4000000.i65a8282775d4e9263da48115",
   "total_results": 3000,
   "totals_are_capped": true
 }

--- a/website/docs/guides/pagination.mdx
+++ b/website/docs/guides/pagination.mdx
@@ -59,6 +59,11 @@ Es el modo por defecto. Además de `limit`, acepta:
 | --- | --- |
 | `page` | Número de página a regresar, empezando desde 1. La página máxima es 30. |
 
+En los listados (`/customers`, `/invoices`, …) `page` es el parámetro compartido,
+que va del 1 al 30. Las **búsquedas de catálogo** (`/catalogs/...`) declaran
+`page` y `limit` de forma propia: ahí `page` acepta `0` (equivalente a la primera
+página) además de `1`–`30`, y `limit` conserva el rango del 1 al 100.
+
 Respuesta:
 
 ```json

--- a/website/docs/guides/pagination.mdx
+++ b/website/docs/guides/pagination.mdx
@@ -119,17 +119,17 @@ de la lista; si `previous_cursor` es `null`, estás en la primera página.
 # Primera página
 curl "https://www.facturapi.io/v2/invoices?pagination=cursor&limit=10" \
   -G \
-  -H "Authorization: Bearer sk_test_API_KEY"
+  -u 'sk_test_API_KEY:'
 
 # Página siguiente (usa next_cursor de la respuesta anterior)
 curl "https://www.facturapi.io/v2/invoices?pagination=cursor&limit=10&after=NEXT_CURSOR" \
   -G \
-  -H "Authorization: Bearer sk_test_API_KEY"
+  -u 'sk_test_API_KEY:'
 
 # Página anterior (usa previous_cursor de la respuesta anterior)
 curl "https://www.facturapi.io/v2/invoices?pagination=cursor&limit=10&before=PREVIOUS_CURSOR" \
   -G \
-  -H "Authorization: Bearer sk_test_API_KEY"
+  -u 'sk_test_API_KEY:'
 ```
 
 Los cursores son tokens opacos y específicos de la búsqueda que los generó: no

--- a/website/i18n/en/docusaurus-plugin-content-docs/current/guides/pagination.mdx
+++ b/website/i18n/en/docusaurus-plugin-content-docs/current/guides/pagination.mdx
@@ -88,6 +88,10 @@ Response:
 }
 ```
 
+`total_results` and `totals_are_capped` are only included on the **first page**
+of the search (when neither `after` nor `before` is sent): the total does not
+change between pages, so subsequent pages only return `data` and the cursors.
+
 ### Navigating between pages
 
 1. **First page:** obtained by not sending `after` or `before`.

--- a/website/i18n/en/docusaurus-plugin-content-docs/current/guides/pagination.mdx
+++ b/website/i18n/en/docusaurus-plugin-content-docs/current/guides/pagination.mdx
@@ -26,6 +26,12 @@ pagination modes that you can choose with the `pagination` parameter:
 For most cases, and especially for large lists, we recommend using
 `pagination=cursor`.
 
+The most important practical difference between both modes is **reach**:
+`pagination=page` only gives access to the first 3,000 results
+(30 pages × 100 per page), while `pagination=cursor` can traverse **all** the
+search results, even when `total_results` is capped at 3,000. If you need to
+export or process more than 3,000 results, use `pagination=cursor`.
+
 ## Common parameters
 
 | Parameter | Type | Description |

--- a/website/i18n/en/docusaurus-plugin-content-docs/current/guides/pagination.mdx
+++ b/website/i18n/en/docusaurus-plugin-content-docs/current/guides/pagination.mdx
@@ -1,0 +1,142 @@
+---
+sidebar_position: 11
+---
+
+# Pagination
+
+All API listing endpoints return paginated results. Facturapi offers two
+pagination modes that you can choose with the `pagination` parameter:
+
+- **`pagination=page`** — the classic mode, based on **numbered pages**. This is
+  the default behavior when `pagination` is not sent.
+- **`pagination=cursor`** — the recommended mode, based on **cursors**. It is
+  faster because it does not run exact counts over the whole collection, and it
+  is designed to traverse large lists sequentially.
+
+## Which mode should I use?
+
+| | `pagination=page` | `pagination=cursor` |
+| --- | --- | --- |
+| Navigation | Jump to a specific page (`page=3`) | Sequential: next / previous |
+| Total results | Exact count (up to 3,000) | Informational (count capped at 3,000) |
+| Performance | Runs a count per search | Faster, no exact counts |
+| Limits | Up to 30 pages | No page limit |
+| Recommended for | Compatibility, UIs with page jumps | Large lists, iteration, exports |
+
+For most cases, and especially for large lists, we recommend using
+`pagination=cursor`.
+
+## Common parameters
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `limit` | `integer` | Maximum number of results to return, from 1 to 100. |
+| `pagination` | `string` | `page` (default) or `cursor`. |
+
+The `page`, `after` and `before` parameters depend on the selected mode and are
+**mutually exclusive** between modes:
+
+- `pagination=page` accepts `page`, but not `after` or `before`.
+- `pagination=cursor` accepts `after` or `before`, but not `page`.
+
+Sending `after` and `before` at the same time returns an error.
+
+## Page pagination (`pagination=page`)
+
+This is the default mode. In addition to `limit`, it accepts:
+
+| Parameter | Description |
+| --- | --- |
+| `page` | Page number to return, starting from 1. The maximum page is 30. |
+
+Response:
+
+```json
+{
+  "data": [ ... ],
+  "page": 1,
+  "total_pages": 3,
+  "total_results": 250,
+  "totals_are_capped": false
+}
+```
+
+## Cursor pagination (`pagination=cursor`)
+
+Instead of a page number, each response returns two cursors that let you move
+forward or backward through the results:
+
+| Parameter | Description |
+| --- | --- |
+| `after` | Returns the results after the given cursor. |
+| `before` | Returns the results before the given cursor. |
+
+Response:
+
+```json
+{
+  "data": [ ... ],
+  "previous_cursor": null,
+  "next_cursor": "d176717f4000000.i65a8282775d4e9263da48115",
+  "total_results": 250,
+  "totals_are_capped": false
+}
+```
+
+### Navigating between pages
+
+1. **First page:** obtained by not sending `after` or `before`.
+   `previous_cursor` returns `null`, meaning there are no previous pages.
+2. **Next page:** send `after` with the `next_cursor` value from the previous
+   response.
+3. **Previous page:** send `before` with the `previous_cursor` value from the
+   previous response.
+
+The presence of `previous_cursor` and `next_cursor` is the only source of truth
+for whether there are more results: if `next_cursor` is `null`, you reached the
+end of the list; if `previous_cursor` is `null`, you are on the first page.
+
+```bash
+# First page
+curl "https://www.facturapi.io/v2/invoices?pagination=cursor&limit=10" \
+  -G \
+  -H "Authorization: Bearer sk_test_API_KEY"
+
+# Next page (use next_cursor from the previous response)
+curl "https://www.facturapi.io/v2/invoices?pagination=cursor&limit=10&after=NEXT_CURSOR" \
+  -G \
+  -H "Authorization: Bearer sk_test_API_KEY"
+
+# Previous page (use previous_cursor from the previous response)
+curl "https://www.facturapi.io/v2/invoices?pagination=cursor&limit=10&before=PREVIOUS_CURSOR" \
+  -G \
+  -H "Authorization: Bearer sk_test_API_KEY"
+```
+
+Cursors are opaque tokens tied to the search that generated them: do not combine
+them with a different search or share them between queries. Using them with a
+different search may return unexpected results.
+
+## Totals and the 3,000 limit
+
+Both modes return `total_results` with the number of elements matching the
+search, **capped at 3,000**:
+
+- If there are 3,000 or fewer results, `total_results` is exact and
+  `totals_are_capped` is `false`.
+- If there are more than 3,000, `total_results` returns `3000` and
+  `totals_are_capped` is `true`, indicating the real total is "more than 3,000".
+
+```json
+{
+  "data": [ ... ],
+  "previous_cursor": "d176717f4000000.i65a8282775d4e9263da48115",
+  "next_cursor": null,
+  "total_results": 3000,
+  "totals_are_capped": true
+}
+```
+
+In `pagination=cursor` mode, `total_results` is informational: the total is
+computed with a count capped at 3,000 instead of an exact count over the whole
+collection, so it stays fast even with very large lists.

--- a/website/i18n/en/docusaurus-plugin-content-docs/current/guides/pagination.mdx
+++ b/website/i18n/en/docusaurus-plugin-content-docs/current/guides/pagination.mdx
@@ -9,18 +9,17 @@ pagination modes that you can choose with the `pagination` parameter:
 
 - **`pagination=page`** — the classic mode, based on **numbered pages**. This is
   the default behavior when `pagination` is not sent.
-- **`pagination=cursor`** — the recommended mode, based on **cursors**. It is
-  faster because it does not run exact counts over the whole collection, and it
-  is designed to traverse large lists sequentially.
+- **`pagination=cursor`** — the recommended mode, based on **cursors**. It
+  traverses results sequentially, without the 30-page limit of `page` mode, and
+  with stable pages even when the data changes.
 
 ## Which mode should I use?
 
 | | `pagination=page` | `pagination=cursor` |
 | --- | --- | --- |
 | Navigation | Jump to a specific page (`page=3`) | Sequential: next / previous |
-| Total results | Exact count (up to 3,000) | Informational (count capped at 3,000) |
-| Performance | Runs a count per search | Faster, no exact counts |
-| Limits | Up to 30 pages | No page limit |
+| Reach | Up to 3,000 results (30 pages × 100) | All search results |
+| Stability | Pages shift when the data changes | Stable pages (position-based) |
 | Recommended for | Compatibility, UIs with page jumps | Large lists, iteration, exports |
 
 For most cases, and especially for large lists, we recommend using
@@ -143,6 +142,7 @@ search, **capped at 3,000**:
 }
 ```
 
-In `pagination=cursor` mode, `total_results` is informational: the total is
-computed with a count capped at 3,000 instead of an exact count over the whole
-collection, so it stays fast even with very large lists.
+In both modes, `total_results` is informational and the count is capped at
+3,000 without traversing the whole collection. The practical advantage of
+`pagination=cursor` is not count speed (both modes cap it), but **reach** and
+**stable pages**.

--- a/website/i18n/en/docusaurus-plugin-content-docs/current/guides/pagination.mdx
+++ b/website/i18n/en/docusaurus-plugin-content-docs/current/guides/pagination.mdx
@@ -5,8 +5,8 @@ sidebar_position: 11
 # Pagination
 
 Customer (`/customers`), invoice (`/invoices`), receipt (`/receipts`), product
-(`/products`) and retention (`/retentions`) listings, as well as catalog
-searches (`/catalogs/...`), return paginated results. On these search
+(`/products`), retention (`/retentions`) and webhook (`/webhooks`) listings, as
+well as catalog searches (`/catalogs/...`), return paginated results. On these
 endpoints, Facturapi offers two pagination modes that you can choose with the
 `pagination` parameter:
 
@@ -15,13 +15,6 @@ endpoints, Facturapi offers two pagination modes that you can choose with the
 - **`pagination=cursor`** — the recommended mode, based on **cursors**. It
   traverses results sequentially, without the 30-page limit of `page` mode, and
   with stable pages even when the data changes.
-
-:::note
-The webhook listing (`GET /webhooks`) also returns paginated results, but it is
-not part of the cursor-enabled searches: it only accepts the `page` and `limit`
-parameters of the `pagination=page` mode. Do not send `pagination=cursor`,
-`after` or `before` to that endpoint.
-:::
 
 ## Which mode should I use?
 
@@ -46,7 +39,7 @@ export or process more than 3,000 results, use `pagination=cursor`.
 | Parameter | Type | Description |
 | --- | --- | --- |
 | `limit` | `integer` | Maximum number of results to return, from 1 to 100. |
-| `pagination` | `string` | `page` (default) or `cursor`. Not available on the webhook listing. |
+| `pagination` | `string` | `page` (default) or `cursor`. |
 
 The `page`, `after` and `before` parameters depend on the selected mode and are
 **mutually exclusive** between modes:

--- a/website/i18n/en/docusaurus-plugin-content-docs/current/guides/pagination.mdx
+++ b/website/i18n/en/docusaurus-plugin-content-docs/current/guides/pagination.mdx
@@ -118,17 +118,17 @@ end of the list; if `previous_cursor` is `null`, you are on the first page.
 # First page
 curl "https://www.facturapi.io/v2/invoices?pagination=cursor&limit=10" \
   -G \
-  -u 'sk_test_API_KEY:'
+  -H "Authorization: Bearer sk_test_API_KEY"
 
 # Next page (use next_cursor from the previous response)
 curl "https://www.facturapi.io/v2/invoices?pagination=cursor&limit=10&after=NEXT_CURSOR" \
   -G \
-  -u 'sk_test_API_KEY:'
+  -H "Authorization: Bearer sk_test_API_KEY"
 
 # Previous page (use previous_cursor from the previous response)
 curl "https://www.facturapi.io/v2/invoices?pagination=cursor&limit=10&before=PREVIOUS_CURSOR" \
   -G \
-  -u 'sk_test_API_KEY:'
+  -H "Authorization: Bearer sk_test_API_KEY"
 ```
 
 Cursors are opaque tokens tied to the search that generated them: do not combine

--- a/website/i18n/en/docusaurus-plugin-content-docs/current/guides/pagination.mdx
+++ b/website/i18n/en/docusaurus-plugin-content-docs/current/guides/pagination.mdx
@@ -148,8 +148,8 @@ search, **capped at 3,000**:
 ```json
 {
   "data": [ ... ],
-  "previous_cursor": "d176717f4000000.i65a8282775d4e9263da48115",
-  "next_cursor": null,
+  "previous_cursor": null,
+  "next_cursor": "d176717f4000000.i65a8282775d4e9263da48115",
   "total_results": 3000,
   "totals_are_capped": true
 }

--- a/website/i18n/en/docusaurus-plugin-content-docs/current/guides/pagination.mdx
+++ b/website/i18n/en/docusaurus-plugin-content-docs/current/guides/pagination.mdx
@@ -58,6 +58,11 @@ This is the default mode. In addition to `limit`, it accepts:
 | --- | --- |
 | `page` | Page number to return, starting from 1. The maximum page is 30. |
 
+On the listings (`/customers`, `/invoices`, …) `page` is the shared parameter,
+ranging from 1 to 30. **Catalog searches** (`/catalogs/...`) declare `page` and
+`limit` on their own: there `page` also accepts `0` (equivalent to the first
+page) in addition to `1`–`30`, and `limit` keeps the 1 to 100 range.
+
 Response:
 
 ```json

--- a/website/i18n/en/docusaurus-plugin-content-docs/current/guides/pagination.mdx
+++ b/website/i18n/en/docusaurus-plugin-content-docs/current/guides/pagination.mdx
@@ -5,9 +5,9 @@ sidebar_position: 11
 # Pagination
 
 Customer (`/customers`), invoice (`/invoices`), receipt (`/receipts`), product
-(`/products`), retention (`/retentions`), organization (`/organizations`) and
-webhook (`/webhooks`) listings, as well as catalog searches (`/catalogs/...`),
-return paginated results. On these
+(`/products`), supplier (`/suppliers`), retention (`/retentions`), organization
+(`/organizations`) and webhook (`/webhooks`) listings, as well as catalog
+searches (`/catalogs/...`), return paginated results. On these
 endpoints, Facturapi offers two pagination modes that you can choose with the
 `pagination` parameter:
 
@@ -70,12 +70,12 @@ This is the default mode. In addition to `limit`, it accepts:
 
 | Parameter | Description |
 | --- | --- |
-| `page` | Page number to return, starting from 1. The maximum page is 30. |
+| `page` | Page number to return, starting from 1. The maximum depends on the 3,000-result cap (see below): with the default `limit` of 100, the maximum page is 30. |
 
 On the listings (`/customers`, `/invoices`, …) `page` is the shared parameter,
-ranging from 1 to 30. **Catalog searches** (`/catalogs/...`) declare `page` and
-`limit` on their own: there `page` also accepts `0` (equivalent to the first
-page) in addition to `1`–`30`, and `limit` keeps the 1 to 100 range.
+starting at 1. **Catalog searches** (`/catalogs/...`) accept the same pagination
+parameters, with `limit` between 1 and 100. The maximum `page` is not fixed: it
+follows from the 3,000-result cap (30 pages with the default `limit` of 100).
 
 Response:
 

--- a/website/i18n/en/docusaurus-plugin-content-docs/current/guides/pagination.mdx
+++ b/website/i18n/en/docusaurus-plugin-content-docs/current/guides/pagination.mdx
@@ -14,7 +14,7 @@ endpoints, Facturapi offers two pagination modes that you can choose with the
 - **`pagination=page`** — the classic mode, based on **numbered pages**. This is
   the default behavior when `pagination` is not sent.
 - **`pagination=cursor`** — the recommended mode, based on **cursors**. It
-  traverses results sequentially, without the 30-page limit of `page` mode, and
+  traverses results sequentially, without the 3,000-result cap of `page` mode, and
   with stable pages even when the data changes.
 
 ## Which mode should I use?

--- a/website/i18n/en/docusaurus-plugin-content-docs/current/guides/pagination.mdx
+++ b/website/i18n/en/docusaurus-plugin-content-docs/current/guides/pagination.mdx
@@ -50,6 +50,20 @@ The `page`, `after` and `before` parameters depend on the selected mode and are
 
 Sending `after` and `before` at the same time returns an error.
 
+### Filter format in the URL
+
+Filters travel in the query string in two formats, the same ones the official
+SDKs send:
+
+- **Objects and ranges**: bracket notation, for example
+  `date[gte]=2026-01-01&date[lt]=2026-02-01` (the `deepObject` style).
+- **Arrays**: the key is repeated, for example `status=valid&status=canceled`
+  (`form` with `explode`).
+
+The API also accepts the most common array variants
+(`status[]=valid&status[]=canceled` and `status[0]=valid&status[1]=canceled`), so
+existing integrations keep working.
+
 ## Page pagination (`pagination=page`)
 
 This is the default mode. In addition to `limit`, it accepts:

--- a/website/i18n/en/docusaurus-plugin-content-docs/current/guides/pagination.mdx
+++ b/website/i18n/en/docusaurus-plugin-content-docs/current/guides/pagination.mdx
@@ -118,17 +118,17 @@ end of the list; if `previous_cursor` is `null`, you are on the first page.
 # First page
 curl "https://www.facturapi.io/v2/invoices?pagination=cursor&limit=10" \
   -G \
-  -H "Authorization: Bearer sk_test_API_KEY"
+  -u 'sk_test_API_KEY:'
 
 # Next page (use next_cursor from the previous response)
 curl "https://www.facturapi.io/v2/invoices?pagination=cursor&limit=10&after=NEXT_CURSOR" \
   -G \
-  -H "Authorization: Bearer sk_test_API_KEY"
+  -u 'sk_test_API_KEY:'
 
 # Previous page (use previous_cursor from the previous response)
 curl "https://www.facturapi.io/v2/invoices?pagination=cursor&limit=10&before=PREVIOUS_CURSOR" \
   -G \
-  -H "Authorization: Bearer sk_test_API_KEY"
+  -u 'sk_test_API_KEY:'
 ```
 
 Cursors are opaque tokens tied to the search that generated them: do not combine

--- a/website/i18n/en/docusaurus-plugin-content-docs/current/guides/pagination.mdx
+++ b/website/i18n/en/docusaurus-plugin-content-docs/current/guides/pagination.mdx
@@ -5,8 +5,9 @@ sidebar_position: 11
 # Pagination
 
 Customer (`/customers`), invoice (`/invoices`), receipt (`/receipts`), product
-(`/products`), retention (`/retentions`) and webhook (`/webhooks`) listings, as
-well as catalog searches (`/catalogs/...`), return paginated results. On these
+(`/products`), retention (`/retentions`), organization (`/organizations`) and
+webhook (`/webhooks`) listings, as well as catalog searches (`/catalogs/...`),
+return paginated results. On these
 endpoints, Facturapi offers two pagination modes that you can choose with the
 `pagination` parameter:
 

--- a/website/i18n/en/docusaurus-plugin-content-docs/current/guides/pagination.mdx
+++ b/website/i18n/en/docusaurus-plugin-content-docs/current/guides/pagination.mdx
@@ -4,14 +4,24 @@ sidebar_position: 11
 
 # Pagination
 
-All API listing endpoints return paginated results. Facturapi offers two
-pagination modes that you can choose with the `pagination` parameter:
+Customer (`/customers`), invoice (`/invoices`), receipt (`/receipts`), product
+(`/products`) and retention (`/retentions`) listings, as well as catalog
+searches (`/catalogs/...`), return paginated results. On these search
+endpoints, Facturapi offers two pagination modes that you can choose with the
+`pagination` parameter:
 
 - **`pagination=page`** — the classic mode, based on **numbered pages**. This is
   the default behavior when `pagination` is not sent.
 - **`pagination=cursor`** — the recommended mode, based on **cursors**. It
   traverses results sequentially, without the 30-page limit of `page` mode, and
   with stable pages even when the data changes.
+
+:::note
+The webhook listing (`GET /webhooks`) also returns paginated results, but it is
+not part of the cursor-enabled searches: it only accepts the `page` and `limit`
+parameters of the `pagination=page` mode. Do not send `pagination=cursor`,
+`after` or `before` to that endpoint.
+:::
 
 ## Which mode should I use?
 
@@ -36,7 +46,7 @@ export or process more than 3,000 results, use `pagination=cursor`.
 | Parameter | Type | Description |
 | --- | --- | --- |
 | `limit` | `integer` | Maximum number of results to return, from 1 to 100. |
-| `pagination` | `string` | `page` (default) or `cursor`. |
+| `pagination` | `string` | `page` (default) or `cursor`. Not available on the webhook listing. |
 
 The `page`, `after` and `before` parameters depend on the selected mode and are
 **mutually exclusive** between modes:

--- a/website/openapi_v2.en.yaml
+++ b/website/openapi_v2.en.yaml
@@ -3513,9 +3513,8 @@ paths:
           schema:
             type: integer
             minimum: 1
-            maximum: 30
             default: 1
-          description: Page of results to return, starting from page 1. The maximum page that can be requested is 30.
+          description: Page of results to return, starting from page 1. The maximum is not fixed; together with `limit` it must fit within the 3,000-result cap (30 pages with the default `limit` of 100).
         - in: query
           name: limit
           schema:

--- a/website/openapi_v2.en.yaml
+++ b/website/openapi_v2.en.yaml
@@ -1041,6 +1041,10 @@ paths:
               ["limit"] = 10
             });
       parameters:
+        - $ref: "#/components/parameters/SearchPagination"
+        - $ref: "#/components/parameters/SearchAfter"
+        - $ref: "#/components/parameters/SearchBefore"
+
         - in: query
           name: q
           schema:
@@ -1142,6 +1146,10 @@ paths:
               ["limit"] = 10
             });
       parameters:
+        - $ref: "#/components/parameters/SearchPagination"
+        - $ref: "#/components/parameters/SearchAfter"
+        - $ref: "#/components/parameters/SearchBefore"
+
         - in: query
           name: q
           schema:
@@ -1225,6 +1233,10 @@ paths:
               ["limit"] = 10
             });
       parameters:
+        - $ref: "#/components/parameters/SearchPagination"
+        - $ref: "#/components/parameters/SearchAfter"
+        - $ref: "#/components/parameters/SearchBefore"
+
         - in: query
           name: q
           schema:
@@ -1320,6 +1332,10 @@ paths:
               ["limit"] = 10
             });
       parameters:
+        - $ref: "#/components/parameters/SearchPagination"
+        - $ref: "#/components/parameters/SearchAfter"
+        - $ref: "#/components/parameters/SearchBefore"
+
         - in: query
           name: q
           schema:
@@ -1403,6 +1419,10 @@ paths:
               ["limit"] = 10
             });
       parameters:
+        - $ref: "#/components/parameters/SearchPagination"
+        - $ref: "#/components/parameters/SearchAfter"
+        - $ref: "#/components/parameters/SearchBefore"
+
         - in: query
           name: q
           schema:
@@ -1486,6 +1506,10 @@ paths:
               ["limit"] = 10
             });
       parameters:
+        - $ref: "#/components/parameters/SearchPagination"
+        - $ref: "#/components/parameters/SearchAfter"
+        - $ref: "#/components/parameters/SearchBefore"
+
         - in: query
           name: q
           schema:
@@ -1569,6 +1593,10 @@ paths:
               ["limit"] = 10
             });
       parameters:
+        - $ref: "#/components/parameters/SearchPagination"
+        - $ref: "#/components/parameters/SearchAfter"
+        - $ref: "#/components/parameters/SearchBefore"
+
         - in: query
           name: q
           schema:
@@ -1652,6 +1680,10 @@ paths:
               ["limit"] = 10
             });
       parameters:
+        - $ref: "#/components/parameters/SearchPagination"
+        - $ref: "#/components/parameters/SearchAfter"
+        - $ref: "#/components/parameters/SearchBefore"
+
         - in: query
           name: q
           schema:
@@ -1735,6 +1767,10 @@ paths:
               ["limit"] = 10
             });
       parameters:
+        - $ref: "#/components/parameters/SearchPagination"
+        - $ref: "#/components/parameters/SearchAfter"
+        - $ref: "#/components/parameters/SearchBefore"
+
         - in: query
           name: q
           schema:
@@ -1832,6 +1868,10 @@ paths:
               ["limit"] = 10
             });
       parameters:
+        - $ref: "#/components/parameters/SearchPagination"
+        - $ref: "#/components/parameters/SearchAfter"
+        - $ref: "#/components/parameters/SearchBefore"
+
         - in: query
           name: q
           schema:
@@ -1915,6 +1955,10 @@ paths:
               ["limit"] = 10
             });
       parameters:
+        - $ref: "#/components/parameters/SearchPagination"
+        - $ref: "#/components/parameters/SearchAfter"
+        - $ref: "#/components/parameters/SearchBefore"
+
         - in: query
           name: q
           schema:
@@ -2144,6 +2188,10 @@ paths:
               "page" => 1
             ]);
       parameters:
+        - $ref: "#/components/parameters/SearchPagination"
+        - $ref: "#/components/parameters/SearchAfter"
+        - $ref: "#/components/parameters/SearchBefore"
+
         - in: query
           name: q
           schema:
@@ -2774,6 +2822,10 @@ paths:
               "page" => 1
             ]);
       parameters:
+        - $ref: "#/components/parameters/SearchPagination"
+        - $ref: "#/components/parameters/SearchAfter"
+        - $ref: "#/components/parameters/SearchBefore"
+
         - in: query
           name: q
           schema:
@@ -3355,6 +3407,10 @@ paths:
               limit => 10,
             ]);
       parameters:
+        - $ref: "#/components/parameters/SearchPagination"
+        - $ref: "#/components/parameters/SearchAfter"
+        - $ref: "#/components/parameters/SearchBefore"
+
         - in: query
           name: q
           schema:
@@ -5334,6 +5390,10 @@ paths:
               limit => 10,
             ]);
       parameters:
+        - $ref: "#/components/parameters/SearchPagination"
+        - $ref: "#/components/parameters/SearchAfter"
+        - $ref: "#/components/parameters/SearchBefore"
+
         - in: query
           name: q
           schema:
@@ -6675,6 +6735,10 @@ paths:
               limit => 10,
             ]);
       parameters:
+        - $ref: "#/components/parameters/SearchPagination"
+        - $ref: "#/components/parameters/SearchAfter"
+        - $ref: "#/components/parameters/SearchBefore"
+
         - in: query
           name: q
           schema:
@@ -7545,6 +7609,10 @@ paths:
 
             $organizations = $facturapi->Organizations->all()
       parameters:
+        - $ref: "#/components/parameters/SearchPagination"
+        - $ref: "#/components/parameters/SearchAfter"
+        - $ref: "#/components/parameters/SearchBefore"
+
         - in: query
           name: q
           schema:
@@ -11502,6 +11570,10 @@ paths:
               "q" => "ukelele"
             ]);
       parameters:
+        - $ref: "#/components/parameters/SearchPagination"
+        - $ref: "#/components/parameters/SearchAfter"
+        - $ref: "#/components/parameters/SearchBefore"
+
         - in: query
           name: q
           schema:
@@ -11585,6 +11657,10 @@ paths:
               "q" => "pulgada"
             ]);
       parameters:
+        - $ref: "#/components/parameters/SearchPagination"
+        - $ref: "#/components/parameters/SearchAfter"
+        - $ref: "#/components/parameters/SearchBefore"
+
         - in: query
           name: q
           schema:
@@ -12199,6 +12275,31 @@ components:
         maximum: 100
       description: Number from 1 to 100 representing the maximum amount of results to return for pagination purposes.
 
+    SearchPagination:
+      in: query
+      name: pagination
+      schema:
+        type: string
+        enum:
+          - page
+          - cursor
+      description: |
+        Pagination mode for the search. `page` (default) or `cursor` (recommended for large lists).
+    SearchAfter:
+      in: query
+      name: after
+      schema:
+        type: string
+      description: |
+        Returns the results after the given cursor. Only with `pagination=cursor`; mutually exclusive with `before`.
+    SearchBefore:
+      in: query
+      name: before
+      schema:
+        type: string
+      description: |
+        Returns the results before the given cursor. Only with `pagination=cursor`; mutually exclusive with `after`.
+
   schemas:
     RelatedResourceMessage:
       type: object
@@ -12385,6 +12486,22 @@ components:
           example: 1
           title: Total results
           description: The total number of results available in the search
+        previous_cursor:
+          type: string
+          example: null
+          title: Previous cursor
+          description: Cursor to fetch the previous page of results. It is `null` on the first page. Only available with `pagination=cursor`.
+        next_cursor:
+          type: string
+          example: null
+          title: Next cursor
+          description: Cursor to fetch the next page of results. It is `null` when there are no more results. Only available with `pagination=cursor`.
+        totals_are_capped:
+          type: boolean
+          example: false
+          title: Totals capped
+          description: Indicates whether `total_results` is capped at 3,000 because there are more results than reported.
+
     ResourceAutoGeneratedProps:
       type: object
       required:

--- a/website/openapi_v2.en.yaml
+++ b/website/openapi_v2.en.yaml
@@ -12468,12 +12468,12 @@ components:
           description: |
             The total number of results available in the search. In `pagination=cursor` mode it is only included on the first page of the search (no `after`/`before`); the total does not change between pages.
         previous_cursor:
-          type: string
+          type: [string, "null"]
           example: null
           title: Previous cursor
           description: Cursor to fetch the previous page of results. It is `null` on the first page. Only available with `pagination=cursor`.
         next_cursor:
-          type: string
+          type: [string, "null"]
           example: null
           title: Next cursor
           description: Cursor to fetch the next page of results. It is `null` when there are no more results. Only available with `pagination=cursor`.

--- a/website/openapi_v2.en.yaml
+++ b/website/openapi_v2.en.yaml
@@ -1058,12 +1058,15 @@ paths:
             minimum: 0
             maximum: 30
           required: false
+          description: Page of results, from 0 to 30. In catalog searches `0` is equivalent to the first page (the shared `page` parameter starts at 1).
         - in: query
           name: limit
           schema:
             type: integer
             minimum: 1
+            maximum: 100
           required: false
+          description: Number from 1 to 100 representing the maximum amount of results to return for pagination purposes.
       responses:
         '200':
           description: Successful search
@@ -1146,11 +1149,14 @@ paths:
             type: integer
             minimum: 0
             maximum: 30
+          description: Page of results, from 0 to 30. In catalog searches `0` is equivalent to the first page (the shared `page` parameter starts at 1).
         - in: query
           name: limit
           schema:
             type: integer
             minimum: 1
+            maximum: 100
+          description: Number from 1 to 100 representing the maximum amount of results to return for pagination purposes.
       responses:
         '200':
           description: Successful search
@@ -1234,12 +1240,15 @@ paths:
             minimum: 0
             maximum: 30
           required: false
+          description: Page of results, from 0 to 30. In catalog searches `0` is equivalent to the first page (the shared `page` parameter starts at 1).
         - in: query
           name: limit
           schema:
             type: integer
             minimum: 1
+            maximum: 100
           required: false
+          description: Number from 1 to 100 representing the maximum amount of results to return for pagination purposes.
       responses:
         '200':
           description: Successful search
@@ -1332,11 +1341,14 @@ paths:
             type: integer
             minimum: 0
             maximum: 30
+          description: Page of results, from 0 to 30. In catalog searches `0` is equivalent to the first page (the shared `page` parameter starts at 1).
         - in: query
           name: limit
           schema:
             type: integer
             minimum: 1
+            maximum: 100
+          description: Number from 1 to 100 representing the maximum amount of results to return for pagination purposes.
       responses:
         '200':
           description: Successful search
@@ -1419,11 +1431,14 @@ paths:
             type: integer
             minimum: 0
             maximum: 30
+          description: Page of results, from 0 to 30. In catalog searches `0` is equivalent to the first page (the shared `page` parameter starts at 1).
         - in: query
           name: limit
           schema:
             type: integer
             minimum: 1
+            maximum: 100
+          description: Number from 1 to 100 representing the maximum amount of results to return for pagination purposes.
       responses:
         '200':
           description: Successful search
@@ -1506,11 +1521,14 @@ paths:
             type: integer
             minimum: 0
             maximum: 30
+          description: Page of results, from 0 to 30. In catalog searches `0` is equivalent to the first page (the shared `page` parameter starts at 1).
         - in: query
           name: limit
           schema:
             type: integer
             minimum: 1
+            maximum: 100
+          description: Number from 1 to 100 representing the maximum amount of results to return for pagination purposes.
       responses:
         '200':
           description: Successful search
@@ -1593,11 +1611,14 @@ paths:
             type: integer
             minimum: 0
             maximum: 30
+          description: Page of results, from 0 to 30. In catalog searches `0` is equivalent to the first page (the shared `page` parameter starts at 1).
         - in: query
           name: limit
           schema:
             type: integer
             minimum: 1
+            maximum: 100
+          description: Number from 1 to 100 representing the maximum amount of results to return for pagination purposes.
       responses:
         '200':
           description: Successful search
@@ -1680,11 +1701,14 @@ paths:
             type: integer
             minimum: 0
             maximum: 30
+          description: Page of results, from 0 to 30. In catalog searches `0` is equivalent to the first page (the shared `page` parameter starts at 1).
         - in: query
           name: limit
           schema:
             type: integer
             minimum: 1
+            maximum: 100
+          description: Number from 1 to 100 representing the maximum amount of results to return for pagination purposes.
       responses:
         '200':
           description: Successful search
@@ -1767,11 +1791,14 @@ paths:
             type: integer
             minimum: 0
             maximum: 30
+          description: Page of results, from 0 to 30. In catalog searches `0` is equivalent to the first page (the shared `page` parameter starts at 1).
         - in: query
           name: limit
           schema:
             type: integer
             minimum: 1
+            maximum: 100
+          description: Number from 1 to 100 representing the maximum amount of results to return for pagination purposes.
       responses:
         '200':
           description: Successful search
@@ -1864,11 +1891,14 @@ paths:
             type: integer
             minimum: 0
             maximum: 30
+          description: Page of results, from 0 to 30. In catalog searches `0` is equivalent to the first page (the shared `page` parameter starts at 1).
         - in: query
           name: limit
           schema:
             type: integer
             minimum: 1
+            maximum: 100
+          description: Number from 1 to 100 representing the maximum amount of results to return for pagination purposes.
       responses:
         '200':
           description: Successful search
@@ -1951,11 +1981,14 @@ paths:
             type: integer
             minimum: 0
             maximum: 30
+          description: Page of results, from 0 to 30. In catalog searches `0` is equivalent to the first page (the shared `page` parameter starts at 1).
         - in: query
           name: limit
           schema:
             type: integer
             minimum: 1
+            maximum: 100
+          description: Number from 1 to 100 representing the maximum amount of results to return for pagination purposes.
       responses:
         '200':
           description: Successful search

--- a/website/openapi_v2.en.yaml
+++ b/website/openapi_v2.en.yaml
@@ -1070,23 +1070,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  page:
-                    type: integer
-                  total_pages:
-                    type: integer
-                  total_results:
-                    type: integer
-                  data:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        key:
-                          type: string
-                        description:
-                          type: string
+                $ref: "#/components/schemas/SearchKeyDescriptionResult"
 
   /catalogs/cartaporte/3.1/transport-configs:
     get:
@@ -1794,21 +1778,17 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  page:
-                    type: integer
-                  total_pages:
-                    type: integer
-                  total_results:
-                    type: integer
-                  data:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        key:
-                          type: string
+                allOf:
+                  - $ref: "#/components/schemas/SearchResult"
+                  - type: object
+                    properties:
+                      data:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            key:
+                              type: string
 
   /catalogs/cartaporte/3.1/port-stations:
     get:

--- a/website/openapi_v2.en.yaml
+++ b/website/openapi_v2.en.yaml
@@ -12485,7 +12485,8 @@ components:
           type: integer
           example: 1
           title: Total results
-          description: The total number of results available in the search
+          description: |
+            The total number of results available in the search. In `pagination=cursor` mode it is only included on the first page of the search (no `after`/`before`); the total does not change between pages.
         previous_cursor:
           type: string
           example: null

--- a/website/openapi_v2.en.yaml
+++ b/website/openapi_v2.en.yaml
@@ -11021,6 +11021,9 @@ paths:
               "page" => 1
             ]);
       parameters:
+        - $ref: "#/components/parameters/SearchPagination"
+        - $ref: "#/components/parameters/SearchAfter"
+        - $ref: "#/components/parameters/SearchBefore"
         - $ref: "#/components/parameters/SearchPage"
         - $ref: "#/components/parameters/SearchLimit"
       security:

--- a/website/openapi_v2.en.yaml
+++ b/website/openapi_v2.en.yaml
@@ -1055,10 +1055,9 @@ paths:
           name: page
           schema:
             type: integer
-            minimum: 0
-            maximum: 30
+            minimum: 1
           required: false
-          description: Page of results, from 0 to 30. In catalog searches `0` is equivalent to the first page (the shared `page` parameter starts at 1).
+          description: Page of results to return, starting from page 1. The maximum is not fixed; together with `limit` it must fit within the 3,000-result cap.
         - in: query
           name: limit
           schema:
@@ -1147,9 +1146,8 @@ paths:
           name: page
           schema:
             type: integer
-            minimum: 0
-            maximum: 30
-          description: Page of results, from 0 to 30. In catalog searches `0` is equivalent to the first page (the shared `page` parameter starts at 1).
+            minimum: 1
+          description: Page of results to return, starting from page 1. The maximum is not fixed; together with `limit` it must fit within the 3,000-result cap.
         - in: query
           name: limit
           schema:
@@ -1237,10 +1235,9 @@ paths:
           name: page
           schema:
             type: integer
-            minimum: 0
-            maximum: 30
+            minimum: 1
           required: false
-          description: Page of results, from 0 to 30. In catalog searches `0` is equivalent to the first page (the shared `page` parameter starts at 1).
+          description: Page of results to return, starting from page 1. The maximum is not fixed; together with `limit` it must fit within the 3,000-result cap.
         - in: query
           name: limit
           schema:
@@ -1339,9 +1336,8 @@ paths:
           name: page
           schema:
             type: integer
-            minimum: 0
-            maximum: 30
-          description: Page of results, from 0 to 30. In catalog searches `0` is equivalent to the first page (the shared `page` parameter starts at 1).
+            minimum: 1
+          description: Page of results to return, starting from page 1. The maximum is not fixed; together with `limit` it must fit within the 3,000-result cap.
         - in: query
           name: limit
           schema:
@@ -1429,9 +1425,8 @@ paths:
           name: page
           schema:
             type: integer
-            minimum: 0
-            maximum: 30
-          description: Page of results, from 0 to 30. In catalog searches `0` is equivalent to the first page (the shared `page` parameter starts at 1).
+            minimum: 1
+          description: Page of results to return, starting from page 1. The maximum is not fixed; together with `limit` it must fit within the 3,000-result cap.
         - in: query
           name: limit
           schema:
@@ -1519,9 +1514,8 @@ paths:
           name: page
           schema:
             type: integer
-            minimum: 0
-            maximum: 30
-          description: Page of results, from 0 to 30. In catalog searches `0` is equivalent to the first page (the shared `page` parameter starts at 1).
+            minimum: 1
+          description: Page of results to return, starting from page 1. The maximum is not fixed; together with `limit` it must fit within the 3,000-result cap.
         - in: query
           name: limit
           schema:
@@ -1609,9 +1603,8 @@ paths:
           name: page
           schema:
             type: integer
-            minimum: 0
-            maximum: 30
-          description: Page of results, from 0 to 30. In catalog searches `0` is equivalent to the first page (the shared `page` parameter starts at 1).
+            minimum: 1
+          description: Page of results to return, starting from page 1. The maximum is not fixed; together with `limit` it must fit within the 3,000-result cap.
         - in: query
           name: limit
           schema:
@@ -1699,9 +1692,8 @@ paths:
           name: page
           schema:
             type: integer
-            minimum: 0
-            maximum: 30
-          description: Page of results, from 0 to 30. In catalog searches `0` is equivalent to the first page (the shared `page` parameter starts at 1).
+            minimum: 1
+          description: Page of results to return, starting from page 1. The maximum is not fixed; together with `limit` it must fit within the 3,000-result cap.
         - in: query
           name: limit
           schema:
@@ -1789,9 +1781,8 @@ paths:
           name: page
           schema:
             type: integer
-            minimum: 0
-            maximum: 30
-          description: Page of results, from 0 to 30. In catalog searches `0` is equivalent to the first page (the shared `page` parameter starts at 1).
+            minimum: 1
+          description: Page of results to return, starting from page 1. The maximum is not fixed; together with `limit` it must fit within the 3,000-result cap.
         - in: query
           name: limit
           schema:
@@ -1889,9 +1880,8 @@ paths:
           name: page
           schema:
             type: integer
-            minimum: 0
-            maximum: 30
-          description: Page of results, from 0 to 30. In catalog searches `0` is equivalent to the first page (the shared `page` parameter starts at 1).
+            minimum: 1
+          description: Page of results to return, starting from page 1. The maximum is not fixed; together with `limit` it must fit within the 3,000-result cap.
         - in: query
           name: limit
           schema:
@@ -1979,9 +1969,8 @@ paths:
           name: page
           schema:
             type: integer
-            minimum: 0
-            maximum: 30
-          description: Page of results, from 0 to 30. In catalog searches `0` is equivalent to the first page (the shared `page` parameter starts at 1).
+            minimum: 1
+          description: Page of results to return, starting from page 1. The maximum is not fixed; together with `limit` it must fit within the 3,000-result cap.
         - in: query
           name: limit
           schema:
@@ -12279,8 +12268,7 @@ components:
       schema:
         type: integer
         minimum: 1
-        maximum: 30
-      description: Page of results to return, starting from page 1. The maximum page that can be requested is 30.
+      description: Page of results to return, starting from page 1. The maximum is not fixed; together with `limit` it must fit within the 3,000-result cap (30 pages with the default `limit` of 100).
     SearchLimit:
       in: query
       name: limit

--- a/website/openapi_v2.en.yaml
+++ b/website/openapi_v2.en.yaml
@@ -17314,7 +17314,7 @@ components:
           type: string
           format: date
           default: End of the last period
-          example: 2022-31-01T23:59:59.999
+          example: 2022-01-31T23:59:59.999
           description: |
             End date of the receipts that will be included in the global invoice.
             By default, this value is the end of the last period (day, week,

--- a/website/openapi_v2.en.yaml
+++ b/website/openapi_v2.en.yaml
@@ -12296,6 +12296,7 @@ components:
       name: pagination
       schema:
         type: string
+        default: page
         enum:
           - page
           - cursor

--- a/website/openapi_v2.yaml
+++ b/website/openapi_v2.yaml
@@ -11246,6 +11246,9 @@ paths:
               "page" => 1
             ]);
       parameters:
+        - $ref: "#/components/parameters/SearchPagination"
+        - $ref: "#/components/parameters/SearchAfter"
+        - $ref: "#/components/parameters/SearchBefore"
         - $ref: "#/components/parameters/SearchPage"
         - $ref: "#/components/parameters/SearchLimit"
       security:

--- a/website/openapi_v2.yaml
+++ b/website/openapi_v2.yaml
@@ -12516,6 +12516,7 @@ components:
       name: pagination
       schema:
         type: string
+        default: page
         enum:
           - page
           - cursor

--- a/website/openapi_v2.yaml
+++ b/website/openapi_v2.yaml
@@ -12502,26 +12502,21 @@ components:
 
   schemas:
     SearchKeyDescriptionResult:
-      type: object
-      properties:
-        page:
-          type: integer
-          description: Número de página actual (base 0).
-        total_pages:
-          type: integer
-          description: Total de páginas disponibles.
-        total_results:
-          type: integer
-          description: Total de resultados encontrados.
-        data:
-          type: array
-          items:
-            type: object
-            properties:
-              key:
-                type: string
-              description:
-                type: string
+      allOf:
+        - $ref: "#/components/schemas/SearchResult"
+        - type: object
+          properties:
+            data:
+              type: array
+              items:
+                type: object
+                properties:
+                  key:
+                    type: string
+                    description: Clave del catálogo
+                  description:
+                    type: string
+                    description: Descripción de la entrada del catálogo
     ErrorMessage:
       type: object
       required:

--- a/website/openapi_v2.yaml
+++ b/website/openapi_v2.yaml
@@ -3755,9 +3755,8 @@ paths:
           schema:
             type: integer
             minimum: 1
-            maximum: 30
             default: 1
-          description: Página de resultados a regresar, empezando desde la página 1. La página máxima que se puede solicitar es 30.
+          description: Página de resultados a regresar, empezando desde la página 1. El máximo no es fijo; junto con `limit` debe caber dentro del tope de 3,000 resultados (con el `limit` por defecto de 100, la página máxima es 30).
         - in: query
           name: limit
           schema:

--- a/website/openapi_v2.yaml
+++ b/website/openapi_v2.yaml
@@ -12718,7 +12718,8 @@ components:
           type: integer
           example: 1
           title: Resultados totales
-          description: Número de elementos individuales en todas las páginas de resultados
+          description: |
+            Número de elementos individuales en todas las páginas de resultados. En modo `pagination=cursor` solo se incluye en la primera página de la búsqueda (sin `after`/`before`); el total no cambia entre páginas.
         previous_cursor:
           type: string
           example: null

--- a/website/openapi_v2.yaml
+++ b/website/openapi_v2.yaml
@@ -1026,9 +1026,8 @@ paths:
           name: page
           schema:
             type: integer
-            minimum: 0
-            maximum: 30
-          description: Página de resultados, de 0 a 30. En las búsquedas de catálogo `0` equivale a la primera página (el parámetro compartido `page` empieza en 1).
+            minimum: 1
+          description: Página de resultados a regresar, empezando desde la página 1. El máximo no es fijo; junto con `limit` debe caber dentro del tope de 3,000 resultados.
         - in: query
           name: limit
           schema:
@@ -1142,9 +1141,8 @@ paths:
           name: page
           schema:
             type: integer
-            minimum: 0
-            maximum: 30
-          description: Página de resultados, de 0 a 30. En las búsquedas de catálogo `0` equivale a la primera página (el parámetro compartido `page` empieza en 1).
+            minimum: 1
+          description: Página de resultados a regresar, empezando desde la página 1. El máximo no es fijo; junto con `limit` debe caber dentro del tope de 3,000 resultados.
         - in: query
           name: limit
           schema:
@@ -1258,9 +1256,8 @@ paths:
           name: page
           schema:
             type: integer
-            minimum: 0
-            maximum: 30
-          description: Página de resultados, de 0 a 30. En las búsquedas de catálogo `0` equivale a la primera página (el parámetro compartido `page` empieza en 1).
+            minimum: 1
+          description: Página de resultados a regresar, empezando desde la página 1. El máximo no es fijo; junto con `limit` debe caber dentro del tope de 3,000 resultados.
         - in: query
           name: limit
           schema:
@@ -1374,9 +1371,8 @@ paths:
           name: page
           schema:
             type: integer
-            minimum: 0
-            maximum: 30
-          description: Página de resultados, de 0 a 30. En las búsquedas de catálogo `0` equivale a la primera página (el parámetro compartido `page` empieza en 1).
+            minimum: 1
+          description: Página de resultados a regresar, empezando desde la página 1. El máximo no es fijo; junto con `limit` debe caber dentro del tope de 3,000 resultados.
         - in: query
           name: limit
           schema:
@@ -1490,9 +1486,8 @@ paths:
           name: page
           schema:
             type: integer
-            minimum: 0
-            maximum: 30
-          description: Página de resultados, de 0 a 30. En las búsquedas de catálogo `0` equivale a la primera página (el parámetro compartido `page` empieza en 1).
+            minimum: 1
+          description: Página de resultados a regresar, empezando desde la página 1. El máximo no es fijo; junto con `limit` debe caber dentro del tope de 3,000 resultados.
         - in: query
           name: limit
           schema:
@@ -1606,9 +1601,8 @@ paths:
           name: page
           schema:
             type: integer
-            minimum: 0
-            maximum: 30
-          description: Página de resultados, de 0 a 30. En las búsquedas de catálogo `0` equivale a la primera página (el parámetro compartido `page` empieza en 1).
+            minimum: 1
+          description: Página de resultados a regresar, empezando desde la página 1. El máximo no es fijo; junto con `limit` debe caber dentro del tope de 3,000 resultados.
         - in: query
           name: limit
           schema:
@@ -1722,9 +1716,8 @@ paths:
           name: page
           schema:
             type: integer
-            minimum: 0
-            maximum: 30
-          description: Página de resultados, de 0 a 30. En las búsquedas de catálogo `0` equivale a la primera página (el parámetro compartido `page` empieza en 1).
+            minimum: 1
+          description: Página de resultados a regresar, empezando desde la página 1. El máximo no es fijo; junto con `limit` debe caber dentro del tope de 3,000 resultados.
         - in: query
           name: limit
           schema:
@@ -1838,9 +1831,8 @@ paths:
           name: page
           schema:
             type: integer
-            minimum: 0
-            maximum: 30
-          description: Página de resultados, de 0 a 30. En las búsquedas de catálogo `0` equivale a la primera página (el parámetro compartido `page` empieza en 1).
+            minimum: 1
+          description: Página de resultados a regresar, empezando desde la página 1. El máximo no es fijo; junto con `limit` debe caber dentro del tope de 3,000 resultados.
         - in: query
           name: limit
           schema:
@@ -1954,9 +1946,8 @@ paths:
           name: page
           schema:
             type: integer
-            minimum: 0
-            maximum: 30
-          description: Página de resultados, de 0 a 30. En las búsquedas de catálogo `0` equivale a la primera página (el parámetro compartido `page` empieza en 1).
+            minimum: 1
+          description: Página de resultados a regresar, empezando desde la página 1. El máximo no es fijo; junto con `limit` debe caber dentro del tope de 3,000 resultados.
         - in: query
           name: limit
           schema:
@@ -2080,9 +2071,8 @@ paths:
           name: page
           schema:
             type: integer
-            minimum: 0
-            maximum: 30
-          description: Página de resultados, de 0 a 30. En las búsquedas de catálogo `0` equivale a la primera página (el parámetro compartido `page` empieza en 1).
+            minimum: 1
+          description: Página de resultados a regresar, empezando desde la página 1. El máximo no es fijo; junto con `limit` debe caber dentro del tope de 3,000 resultados.
         - in: query
           name: limit
           schema:
@@ -2196,9 +2186,8 @@ paths:
           name: page
           schema:
             type: integer
-            minimum: 0
-            maximum: 30
-          description: Página de resultados, de 0 a 30. En las búsquedas de catálogo `0` equivale a la primera página (el parámetro compartido `page` empieza en 1).
+            minimum: 1
+          description: Página de resultados a regresar, empezando desde la página 1. El máximo no es fijo; junto con `limit` debe caber dentro del tope de 3,000 resultados.
         - in: query
           name: limit
           schema:
@@ -12499,8 +12488,7 @@ components:
       schema:
         type: integer
         minimum: 1
-        maximum: 30
-      description: Página de resultados a regresar, empezando desde la página 1. La página máxima que se puede solicitar es 30.
+      description: Página de resultados a regresar, empezando desde la página 1. El máximo no es fijo; junto con `limit` debe caber dentro del tope de 3,000 resultados (con el `limit` por defecto de 100, la página máxima es 30).
     SearchLimit:
       in: query
       name: limit

--- a/website/openapi_v2.yaml
+++ b/website/openapi_v2.yaml
@@ -1028,11 +1028,14 @@ paths:
             type: integer
             minimum: 0
             maximum: 30
+          description: Página de resultados, de 0 a 30. En las búsquedas de catálogo `0` equivale a la primera página (el parámetro compartido `page` empieza en 1).
         - in: query
           name: limit
           schema:
             type: integer
             minimum: 1
+            maximum: 100
+          description: Número del 1 al 100 que representa la cantidad máxima de resultados a regresar con motivos de paginación.
       responses:
         '200':
           description: Búsqueda exitosa
@@ -1141,11 +1144,14 @@ paths:
             type: integer
             minimum: 0
             maximum: 30
+          description: Página de resultados, de 0 a 30. En las búsquedas de catálogo `0` equivale a la primera página (el parámetro compartido `page` empieza en 1).
         - in: query
           name: limit
           schema:
             type: integer
             minimum: 1
+            maximum: 100
+          description: Número del 1 al 100 que representa la cantidad máxima de resultados a regresar con motivos de paginación.
       responses:
         '200':
           description: Búsqueda exitosa
@@ -1254,11 +1260,14 @@ paths:
             type: integer
             minimum: 0
             maximum: 30
+          description: Página de resultados, de 0 a 30. En las búsquedas de catálogo `0` equivale a la primera página (el parámetro compartido `page` empieza en 1).
         - in: query
           name: limit
           schema:
             type: integer
             minimum: 1
+            maximum: 100
+          description: Número del 1 al 100 que representa la cantidad máxima de resultados a regresar con motivos de paginación.
       responses:
         '200':
           description: Búsqueda exitosa
@@ -1367,11 +1376,14 @@ paths:
             type: integer
             minimum: 0
             maximum: 30
+          description: Página de resultados, de 0 a 30. En las búsquedas de catálogo `0` equivale a la primera página (el parámetro compartido `page` empieza en 1).
         - in: query
           name: limit
           schema:
             type: integer
             minimum: 1
+            maximum: 100
+          description: Número del 1 al 100 que representa la cantidad máxima de resultados a regresar con motivos de paginación.
       responses:
         '200':
           description: Búsqueda exitosa
@@ -1480,11 +1492,14 @@ paths:
             type: integer
             minimum: 0
             maximum: 30
+          description: Página de resultados, de 0 a 30. En las búsquedas de catálogo `0` equivale a la primera página (el parámetro compartido `page` empieza en 1).
         - in: query
           name: limit
           schema:
             type: integer
             minimum: 1
+            maximum: 100
+          description: Número del 1 al 100 que representa la cantidad máxima de resultados a regresar con motivos de paginación.
       responses:
         '200':
           description: Búsqueda exitosa
@@ -1593,11 +1608,14 @@ paths:
             type: integer
             minimum: 0
             maximum: 30
+          description: Página de resultados, de 0 a 30. En las búsquedas de catálogo `0` equivale a la primera página (el parámetro compartido `page` empieza en 1).
         - in: query
           name: limit
           schema:
             type: integer
             minimum: 1
+            maximum: 100
+          description: Número del 1 al 100 que representa la cantidad máxima de resultados a regresar con motivos de paginación.
       responses:
         '200':
           description: Búsqueda exitosa
@@ -1706,11 +1724,14 @@ paths:
             type: integer
             minimum: 0
             maximum: 30
+          description: Página de resultados, de 0 a 30. En las búsquedas de catálogo `0` equivale a la primera página (el parámetro compartido `page` empieza en 1).
         - in: query
           name: limit
           schema:
             type: integer
             minimum: 1
+            maximum: 100
+          description: Número del 1 al 100 que representa la cantidad máxima de resultados a regresar con motivos de paginación.
       responses:
         '200':
           description: Búsqueda exitosa
@@ -1819,11 +1840,14 @@ paths:
             type: integer
             minimum: 0
             maximum: 30
+          description: Página de resultados, de 0 a 30. En las búsquedas de catálogo `0` equivale a la primera página (el parámetro compartido `page` empieza en 1).
         - in: query
           name: limit
           schema:
             type: integer
             minimum: 1
+            maximum: 100
+          description: Número del 1 al 100 que representa la cantidad máxima de resultados a regresar con motivos de paginación.
       responses:
         '200':
           description: Búsqueda exitosa
@@ -1932,11 +1956,14 @@ paths:
             type: integer
             minimum: 0
             maximum: 30
+          description: Página de resultados, de 0 a 30. En las búsquedas de catálogo `0` equivale a la primera página (el parámetro compartido `page` empieza en 1).
         - in: query
           name: limit
           schema:
             type: integer
             minimum: 1
+            maximum: 100
+          description: Número del 1 al 100 que representa la cantidad máxima de resultados a regresar con motivos de paginación.
       responses:
         '200':
           description: Búsqueda exitosa
@@ -2055,11 +2082,14 @@ paths:
             type: integer
             minimum: 0
             maximum: 30
+          description: Página de resultados, de 0 a 30. En las búsquedas de catálogo `0` equivale a la primera página (el parámetro compartido `page` empieza en 1).
         - in: query
           name: limit
           schema:
             type: integer
             minimum: 1
+            maximum: 100
+          description: Número del 1 al 100 que representa la cantidad máxima de resultados a regresar con motivos de paginación.
       responses:
         '200':
           description: Búsqueda exitosa
@@ -2168,11 +2198,14 @@ paths:
             type: integer
             minimum: 0
             maximum: 30
+          description: Página de resultados, de 0 a 30. En las búsquedas de catálogo `0` equivale a la primera página (el parámetro compartido `page` empieza en 1).
         - in: query
           name: limit
           schema:
             type: integer
             minimum: 1
+            maximum: 100
+          description: Número del 1 al 100 que representa la cantidad máxima de resultados a regresar con motivos de paginación.
       responses:
         '200':
           description: Búsqueda exitosa

--- a/website/openapi_v2.yaml
+++ b/website/openapi_v2.yaml
@@ -1943,21 +1943,17 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  page:
-                    type: integer
-                  total_pages:
-                    type: integer
-                  total_results:
-                    type: integer
-                  data:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        key:
-                          type: string
+                allOf:
+                  - $ref: "#/components/schemas/SearchResult"
+                  - type: object
+                    properties:
+                      data:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            key:
+                              type: string
         '400':
           description: Error en parámetros de la petición
           content:

--- a/website/openapi_v2.yaml
+++ b/website/openapi_v2.yaml
@@ -12717,12 +12717,12 @@ components:
           description: |
             Número de elementos individuales en todas las páginas de resultados. En modo `pagination=cursor` solo se incluye en la primera página de la búsqueda (sin `after`/`before`); el total no cambia entre páginas.
         previous_cursor:
-          type: string
+          type: [string, "null"]
           example: null
           title: Cursor anterior
           description: Cursor para obtener la página anterior de resultados. Es `null` en la primera página. Solo disponible con `pagination=cursor`.
         next_cursor:
-          type: string
+          type: [string, "null"]
           example: null
           title: Cursor siguiente
           description: Cursor para obtener la página siguiente de resultados. Es `null` cuando no hay más resultados. Solo disponible con `pagination=cursor`.

--- a/website/openapi_v2.yaml
+++ b/website/openapi_v2.yaml
@@ -17579,7 +17579,7 @@ components:
           type: string
           format: date
           default: Fin del último periodo
-          example: 2022-31-01T23:59:59.999
+          example: 2022-01-31T23:59:59.999
           description: |
             Fecha final de los recibos que se incluirán en la factura global.
             Por default, este valor es el fin del último periodo (día, semana,

--- a/website/openapi_v2.yaml
+++ b/website/openapi_v2.yaml
@@ -1012,6 +1012,10 @@ paths:
               ["limit"] = 10
             });
       parameters:
+        - $ref: "#/components/parameters/SearchPagination"
+        - $ref: "#/components/parameters/SearchAfter"
+        - $ref: "#/components/parameters/SearchBefore"
+
         - in: query
           name: q
           schema:
@@ -1121,6 +1125,10 @@ paths:
               ["limit"] = 10
             });
       parameters:
+        - $ref: "#/components/parameters/SearchPagination"
+        - $ref: "#/components/parameters/SearchAfter"
+        - $ref: "#/components/parameters/SearchBefore"
+
         - in: query
           name: q
           schema:
@@ -1230,6 +1238,10 @@ paths:
               ["limit"] = 10
             });
       parameters:
+        - $ref: "#/components/parameters/SearchPagination"
+        - $ref: "#/components/parameters/SearchAfter"
+        - $ref: "#/components/parameters/SearchBefore"
+
         - in: query
           name: q
           schema:
@@ -1339,6 +1351,10 @@ paths:
               ["limit"] = 10
             });
       parameters:
+        - $ref: "#/components/parameters/SearchPagination"
+        - $ref: "#/components/parameters/SearchAfter"
+        - $ref: "#/components/parameters/SearchBefore"
+
         - in: query
           name: q
           schema:
@@ -1448,6 +1464,10 @@ paths:
               ["limit"] = 10
             });
       parameters:
+        - $ref: "#/components/parameters/SearchPagination"
+        - $ref: "#/components/parameters/SearchAfter"
+        - $ref: "#/components/parameters/SearchBefore"
+
         - in: query
           name: q
           schema:
@@ -1557,6 +1577,10 @@ paths:
               ["limit"] = 10
             });
       parameters:
+        - $ref: "#/components/parameters/SearchPagination"
+        - $ref: "#/components/parameters/SearchAfter"
+        - $ref: "#/components/parameters/SearchBefore"
+
         - in: query
           name: q
           schema:
@@ -1666,6 +1690,10 @@ paths:
               ["limit"] = 10
             });
       parameters:
+        - $ref: "#/components/parameters/SearchPagination"
+        - $ref: "#/components/parameters/SearchAfter"
+        - $ref: "#/components/parameters/SearchBefore"
+
         - in: query
           name: q
           schema:
@@ -1775,6 +1803,10 @@ paths:
               ["limit"] = 10
             });
       parameters:
+        - $ref: "#/components/parameters/SearchPagination"
+        - $ref: "#/components/parameters/SearchAfter"
+        - $ref: "#/components/parameters/SearchBefore"
+
         - in: query
           name: q
           schema:
@@ -1884,6 +1916,10 @@ paths:
               ["limit"] = 10
             });
       parameters:
+        - $ref: "#/components/parameters/SearchPagination"
+        - $ref: "#/components/parameters/SearchAfter"
+        - $ref: "#/components/parameters/SearchBefore"
+
         - in: query
           name: q
           schema:
@@ -2007,6 +2043,10 @@ paths:
               ["limit"] = 10
             });
       parameters:
+        - $ref: "#/components/parameters/SearchPagination"
+        - $ref: "#/components/parameters/SearchAfter"
+        - $ref: "#/components/parameters/SearchBefore"
+
         - in: query
           name: q
           schema:
@@ -2116,6 +2156,10 @@ paths:
               ["limit"] = 10
             });
       parameters:
+        - $ref: "#/components/parameters/SearchPagination"
+        - $ref: "#/components/parameters/SearchAfter"
+        - $ref: "#/components/parameters/SearchBefore"
+
         - in: query
           name: q
           schema:
@@ -2372,6 +2416,10 @@ paths:
               "page" => 1
             ]);
       parameters:
+        - $ref: "#/components/parameters/SearchPagination"
+        - $ref: "#/components/parameters/SearchAfter"
+        - $ref: "#/components/parameters/SearchBefore"
+
         - in: query
           name: q
           schema:
@@ -3002,6 +3050,10 @@ paths:
               "page" => 1
             ]);
       parameters:
+        - $ref: "#/components/parameters/SearchPagination"
+        - $ref: "#/components/parameters/SearchAfter"
+        - $ref: "#/components/parameters/SearchBefore"
+
         - in: query
           name: q
           schema:
@@ -3581,6 +3633,10 @@ paths:
               limit => 10,
             ]);
       parameters:
+        - $ref: "#/components/parameters/SearchPagination"
+        - $ref: "#/components/parameters/SearchAfter"
+        - $ref: "#/components/parameters/SearchBefore"
+
         - in: query
           name: q
           schema:
@@ -5554,6 +5610,10 @@ paths:
               limit => 10,
             ]);
       parameters:
+        - $ref: "#/components/parameters/SearchPagination"
+        - $ref: "#/components/parameters/SearchAfter"
+        - $ref: "#/components/parameters/SearchBefore"
+
         - in: query
           name: q
           schema:
@@ -6891,6 +6951,10 @@ paths:
               limit => 10,
             ]);
       parameters:
+        - $ref: "#/components/parameters/SearchPagination"
+        - $ref: "#/components/parameters/SearchAfter"
+        - $ref: "#/components/parameters/SearchBefore"
+
         - in: query
           name: q
           schema:
@@ -7761,6 +7825,10 @@ paths:
 
             $organizations = $facturapi->Organizations->all()
       parameters:
+        - $ref: "#/components/parameters/SearchPagination"
+        - $ref: "#/components/parameters/SearchAfter"
+        - $ref: "#/components/parameters/SearchBefore"
+
         - in: query
           name: q
           schema:
@@ -11706,6 +11774,10 @@ paths:
               "q" => "ukelele"
             ]);
       parameters:
+        - $ref: "#/components/parameters/SearchPagination"
+        - $ref: "#/components/parameters/SearchAfter"
+        - $ref: "#/components/parameters/SearchBefore"
+
         - in: query
           name: q
           schema:
@@ -11789,6 +11861,10 @@ paths:
               "q" => "pulgada"
             ]);
       parameters:
+        - $ref: "#/components/parameters/SearchPagination"
+        - $ref: "#/components/parameters/SearchAfter"
+        - $ref: "#/components/parameters/SearchBefore"
+
         - in: query
           name: q
           schema:
@@ -12403,6 +12479,31 @@ components:
         maximum: 100
       description: Número del 1 al 100 que representa la cantidad máxima de resultados a regresar con motivos de paginación.
 
+    SearchPagination:
+      in: query
+      name: pagination
+      schema:
+        type: string
+        enum:
+          - page
+          - cursor
+      description: |
+        Modo de paginación de la búsqueda. `page` (por defecto) o `cursor` (recomendado para listas grandes).
+    SearchAfter:
+      in: query
+      name: after
+      schema:
+        type: string
+      description: |
+        Devuelve los resultados posteriores al cursor indicado. Solo con `pagination=cursor`; mutuamente excluyente con `before`.
+    SearchBefore:
+      in: query
+      name: before
+      schema:
+        type: string
+      description: |
+        Devuelve los resultados anteriores al cursor indicado. Solo con `pagination=cursor`; mutuamente excluyente con `after`.
+
   schemas:
     SearchKeyDescriptionResult:
       type: object
@@ -12618,6 +12719,22 @@ components:
           example: 1
           title: Resultados totales
           description: Número de elementos individuales en todas las páginas de resultados
+        previous_cursor:
+          type: string
+          example: null
+          title: Cursor anterior
+          description: Cursor para obtener la página anterior de resultados. Es `null` en la primera página. Solo disponible con `pagination=cursor`.
+        next_cursor:
+          type: string
+          example: null
+          title: Cursor siguiente
+          description: Cursor para obtener la página siguiente de resultados. Es `null` cuando no hay más resultados. Solo disponible con `pagination=cursor`.
+        totals_are_capped:
+          type: boolean
+          example: false
+          title: Resultados con tope
+          description: Indica si `total_results` está limitado a 3,000 porque existen más resultados de los reportados.
+
     ResourceAutoGeneratedProps:
       type: object
       required:


### PR DESCRIPTION
## Cambios

- **Guía de paginación** (`docs/guides/pagination.mdx`, ES + EN): comparativa `pagination=page` vs `pagination=cursor`, parámetros (`pagination`, `limit`, `page`, `after`, `before`) y combinaciones válidas, formas de respuesta de ambos modos (`previous_cursor`, `next_cursor`, `total_results`, `totals_are_capped`), navegación secuencial con cursores y tope de 3,000 resultados.
- **OpenAPI (ES y EN)**: parámetros compartidos `SearchPagination`, `SearchAfter`, `SearchBefore` en `components.parameters`, con `$ref` en los 19 endpoints de búsqueda (catálogos, customers, invoices, organizations, products, receipts, retentions); `previous_cursor`, `next_cursor` y `totals_are_capped` en el schema compartido `SearchResult`.
- **CHANGELOG.md**: entrada de release.

## Validación

- Ambos YAML parsean y los 57 `$ref` nuevos quedan dentro de listas `parameters`.
- `git diff --check` sin errores.
