### PR TITLE
docs(invoices): document payment summary endpoint

### DIFF
--- a/website/docs/guides/invoices/pago.mdx
+++ b/website/docs/guides/invoices/pago.mdx
@@ -496,5 +496,51 @@ const invoice = await facturapi.invoices.create({
 });
 ```
 
-Cuando el pago cubre varias facturas, llama al método una vez por factura con el monto que
-le corresponde a cada una y arma el complemento con los resúmenes resultantes.
+Cada resumen contiene, listo para el CFDI: `uuid`, `installment` (la parcialidad
+que corresponde según el historial de pagos), `last_balance` (el saldo anterior),
+`amount` (el monto pagado en esta parcialidad) y `taxes` con las bases e impuestos
+ya prorrateados al monto pagado. No necesitas mapear nada: el objeto completo va
+como elemento de `related_documents`.
+
+### Un pago que cubre varias facturas
+
+Cuando un mismo pago liquida varias facturas, pide un resumen por factura con el
+monto que le corresponde a cada una y arma el complemento con todos los resúmenes:
+
+```javascript
+import Facturapi from 'facturapi'
+const facturapi = new Facturapi('sk_test_API_KEY');
+
+// Los montos que decide el negocio: cuánto se abona a cada factura.
+const pagos = [
+  { invoiceId: '58e93bd8e86eb318b019743d', amount: 100 },
+  { invoiceId: '7f104ce9f97eb428c130854e', amount: 250 }
+];
+
+const related_documents = await Promise.all(
+  pagos.map(({ invoiceId, amount }) =>
+    facturapi.invoices.paymentSummary(invoiceId, { amount })
+  )
+);
+
+const invoice = await facturapi.invoices.create({
+  type: 'P',
+  customer: customer.id,
+  complements: [
+    {
+      type: 'pago',
+      data: [
+        {
+          payment_form: '28',
+          related_documents
+        }
+      ]
+    }
+  ]
+});
+```
+
+Si el monto excede el saldo de alguna factura, el endpoint responde un error
+(`amount_exceeds_related_document_balance`) antes de crear nada. Lo mismo sucede
+si la factura no es candidata a pago: el endpoint solo acepta facturas de ingreso
+timbradas con método de pago PPD que sigan vigentes.

--- a/website/docs/guides/invoices/pago.mdx
+++ b/website/docs/guides/invoices/pago.mdx
@@ -456,3 +456,45 @@ curl https://www.facturapi.io/v2/invoices \
 
 </TabItem>
 </Tabs>
+
+## Resumen de pago
+
+Para construir los `related_documents` de un Complemento de Pago necesitas, por cada factura
+relacionada: el número de parcialidad que corresponde, el saldo anterior y el desglose de impuestos
+prorrateado al monto que se paga. Calcular estos valores a mano es propenso a errores, sobre todo en
+pagos en varias parcialidades o con retenciones.
+
+El endpoint [Resumen de pago](/api/#tag/invoice/operation/getInvoicePaymentSummary) hace ese cálculo
+por ti: devuelve el objeto `related_document` listo para agregarse al complemento.
+
+```javascript
+import Facturapi from 'facturapi'
+const facturapi = new Facturapi('sk_test_API_KEY');
+
+// Monto que se paga de esta factura, en la divisa de la factura.
+// No puede exceder el saldo pendiente (amount_due).
+const summary = await facturapi.invoices.paymentSummary(
+  '58e93bd8e86eb318b019743d',
+  { amount: 100 }
+);
+
+// El resumen es un elemento de related_documents listo para usarse
+const invoice = await facturapi.invoices.create({
+  type: 'P',
+  customer: customer.id,
+  complements: [
+    {
+      type: 'pago',
+      data: [
+        {
+          payment_form: '28',
+          related_documents: [summary]
+        }
+      ]
+    }
+  ]
+});
+```
+
+Cuando el pago cubre varias facturas, llama al método una vez por factura con el monto que
+le corresponde a cada una y arma el complemento con los resúmenes resultantes.

--- a/website/openapi_v2.en.yaml
+++ b/website/openapi_v2.en.yaml
@@ -4598,6 +4598,123 @@ paths:
         "500":
           $ref: "#/components/responses/UnexpectedError"
 
+  /invoices/{invoice_id}/payment-summary:
+    get:
+      operationId: getInvoicePaymentSummary
+      tags:
+        - invoice
+      summary: Payment summary
+      description: |
+        Returns the information needed to add this invoice as a related document in a payment
+        complement (complemento de pago): the installment number according to the payment history,
+        the previous balance (`last_balance`), and the invoice tax breakdown prorated to the amount
+        being paid.
+
+        The response is ready to be used as an element of `related_documents` when
+        [creating a Payment invoice](#tag/invoice/operation/createInvoice).
+
+        The `amount` parameter must be expressed in the invoice currency and cannot exceed the
+        outstanding balance (`amount_due`). When the payment is received in a different currency,
+        convert the amount before calling this method.
+      x-codeSamples:
+        - lang: Bash
+          label: cURL
+          source: |
+            curl "https://www.facturapi.io/v2/invoices/58e93bd8e86eb318b019743d/payment-summary?amount=100" \
+              -H "Authorization: Bearer sk_test_API_KEY"
+
+        - lang: JavaScript
+          label: Node.js
+          source: |
+            import Facturapi from 'facturapi'
+            const facturapi = new Facturapi('sk_test_API_KEY');
+
+            const summary = await facturapi.invoices.paymentSummary(
+              '58e93bd8e86eb318b019743d',
+              { amount: 100 }
+            );
+      parameters:
+        - in: path
+          name: invoice_id
+          schema:
+            type: string
+          required: true
+          description: ID of the income invoice (PPD payment method) being paid
+        - in: query
+          name: amount
+          schema:
+            type: number
+          required: true
+          description: Amount being paid on this invoice, expressed in the invoice currency. Cannot exceed the outstanding balance.
+      security:
+        - "SecretLiveKey": []
+        - "SecretTestKey": []
+      responses:
+        "200":
+          description: Related document summary
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  uuid:
+                    type: string
+                    description: Invoice UUID
+                  folio_number:
+                    type: number
+                    nullable: true
+                    description: Invoice folio number
+                  series:
+                    type: string
+                    nullable: true
+                    description: Invoice series
+                  installment:
+                    type: number
+                    description: Installment number corresponding to this payment
+                  last_balance:
+                    type: number
+                    description: Invoice outstanding balance before this payment
+                  total:
+                    type: number
+                    description: Invoice total
+                  currency:
+                    type: string
+                    description: Invoice currency
+                  amount:
+                    type: number
+                    description: Amount paid in this installment
+                  taxes:
+                    type: array
+                    description: Invoice taxes prorated to the paid amount
+                    items:
+                      type: object
+                      properties:
+                        base:
+                          type: number
+                          description: Tax base prorated to the paid amount
+                        rate:
+                          type: number
+                          description: Tax rate or quota
+                        type:
+                          type: string
+                          description: Tax type (VAT, income tax withholding, etc.)
+                        factor:
+                          type: string
+                          description: Factor type (Rate, Exempt, etc.)
+                        withholding:
+                          type: boolean
+                          description: Whether this tax is a withholding
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthenticated"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "429":
+          $ref: "#/components/responses/RateLimited"
+        "500":
+          $ref: "#/components/responses/UnexpectedError"
+
   /invoices/{invoice_id}/{format}:
     get:
       operationId: downloadInvoice

--- a/website/openapi_v2.en.yaml
+++ b/website/openapi_v2.en.yaml
@@ -4633,6 +4633,23 @@ paths:
               '58e93bd8e86eb318b019743d',
               { amount: 100 }
             );
+
+            // The summary goes as-is into the complement's related documents
+            const invoice = await facturapi.invoices.create({
+              type: 'P',
+              customer: 'customer_id',
+              complements: [
+                {
+                  type: 'pago',
+                  data: [
+                    {
+                      payment_form: '28',
+                      related_documents: [summary]
+                    }
+                  ]
+                }
+              ]
+            });
       parameters:
         - in: path
           name: invoice_id
@@ -4703,6 +4720,21 @@ paths:
                         withholding:
                           type: boolean
                           description: Whether this tax is a withholding
+                example:
+                  uuid: 39c85a3f-275b-4341-b259-e8971d9f8a94
+                  folio_number: 914
+                  series: F
+                  installment: 2
+                  last_balance: 245.6
+                  total: 345.6
+                  currency: MXN
+                  amount: 100
+                  taxes:
+                    - base: 86.21
+                      rate: 0.16
+                      type: IVA
+                      factor: Tasa
+                      withholding: false
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":

--- a/website/openapi_v2.en.yaml
+++ b/website/openapi_v2.en.yaml
@@ -4662,8 +4662,7 @@ paths:
                     description: Invoice UUID
                   folio_number:
                     type: number
-                    nullable: true
-                    description: Invoice folio number
+                    description: Invoice folio number. Omitted when the invoice has none registered.
                   series:
                     type: string
                     nullable: true

--- a/website/openapi_v2.yaml
+++ b/website/openapi_v2.yaml
@@ -4855,6 +4855,23 @@ paths:
               '58e93bd8e86eb318b019743d',
               { amount: 100 }
             );
+
+            // El resumen va completo como related_document del complemento
+            const invoice = await facturapi.invoices.create({
+              type: 'P',
+              customer: 'customer_id',
+              complements: [
+                {
+                  type: 'pago',
+                  data: [
+                    {
+                      payment_form: '28',
+                      related_documents: [summary]
+                    }
+                  ]
+                }
+              ]
+            });
       parameters:
         - in: path
           name: invoice_id
@@ -4925,6 +4942,21 @@ paths:
                         withholding:
                           type: boolean
                           description: Indica si se trata de una retención
+                example:
+                  uuid: 39c85a3f-275b-4341-b259-e8971d9f8a94
+                  folio_number: 914
+                  series: F
+                  installment: 2
+                  last_balance: 245.6
+                  total: 345.6
+                  currency: MXN
+                  amount: 100
+                  taxes:
+                    - base: 86.21
+                      rate: 0.16
+                      type: IVA
+                      factor: Tasa
+                      withholding: false
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":

--- a/website/openapi_v2.yaml
+++ b/website/openapi_v2.yaml
@@ -4820,6 +4820,123 @@ paths:
         "500":
           $ref: "#/components/responses/UnexpectedError"
 
+  /invoices/{invoice_id}/payment-summary:
+    get:
+      operationId: getInvoicePaymentSummary
+      tags:
+        - invoice
+      summary: Resumen de pago
+      description: |
+        Devuelve la información necesaria para agregar esta factura como documento relacionado en un
+        Comprobante de Pago (complemento de pago): el número de parcialidad que corresponde según el
+        historial de pagos, el saldo anterior (`last_balance`) y el desglose de impuestos de la factura
+        prorrateado al monto que se pretende pagar.
+
+        El valor de retorno está listo para usarse como elemento de `related_documents` al
+        [crear una factura de tipo Pago](#tag/invoice/operation/createInvoice).
+
+        El parámetro `amount` debe expresarse en la divisa de la factura y no puede exceder el saldo
+        pendiente (`amount_due`). Cuando el pago se recibe en otra divisa, convierte el monto antes de
+        llamar este método.
+      x-codeSamples:
+        - lang: Bash
+          label: cURL
+          source: |
+            curl "https://www.facturapi.io/v2/invoices/58e93bd8e86eb318b019743d/payment-summary?amount=100" \
+              -H "Authorization: Bearer sk_test_API_KEY"
+
+        - lang: JavaScript
+          label: Node.js
+          source: |
+            import Facturapi from 'facturapi'
+            const facturapi = new Facturapi('sk_test_API_KEY');
+
+            const summary = await facturapi.invoices.paymentSummary(
+              '58e93bd8e86eb318b019743d',
+              { amount: 100 }
+            );
+      parameters:
+        - in: path
+          name: invoice_id
+          schema:
+            type: string
+          required: true
+          description: ID de la factura de ingreso (método de pago PPD) que se desea pagar
+        - in: query
+          name: amount
+          schema:
+            type: number
+          required: true
+          description: Monto que se paga de esta factura, expresado en la divisa de la factura. No puede exceder el saldo pendiente.
+      security:
+        - "SecretLiveKey": []
+        - "SecretTestKey": []
+      responses:
+        "200":
+          description: Resumen del documento relacionado
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  uuid:
+                    type: string
+                    description: UUID de la factura
+                  folio_number:
+                    type: number
+                    nullable: true
+                    description: Folio de la factura
+                  series:
+                    type: string
+                    nullable: true
+                    description: Serie de la factura
+                  installment:
+                    type: number
+                    description: Número de parcialidad que corresponde a este pago
+                  last_balance:
+                    type: number
+                    description: Saldo pendiente de la factura antes de aplicar este pago
+                  total:
+                    type: number
+                    description: Total de la factura
+                  currency:
+                    type: string
+                    description: Divisa de la factura
+                  amount:
+                    type: number
+                    description: Monto que se paga en esta parcialidad
+                  taxes:
+                    type: array
+                    description: Impuestos de la factura prorrateados al monto pagado
+                    items:
+                      type: object
+                      properties:
+                        base:
+                          type: number
+                          description: Base del impuesto prorrateada al monto pagado
+                        rate:
+                          type: number
+                          description: Tasa o cuota del impuesto
+                        type:
+                          type: string
+                          description: Tipo de impuesto (IVA, ISR, etc.)
+                        factor:
+                          type: string
+                          description: Tipo de factor (Tasa, Exento, etc.)
+                        withholding:
+                          type: boolean
+                          description: Indica si se trata de una retención
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthenticated"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "429":
+          $ref: "#/components/responses/RateLimited"
+        "500":
+          $ref: "#/components/responses/UnexpectedError"
+
   /invoices/{invoice_id}/{format}:
     get:
       operationId: downloadInvoice

--- a/website/openapi_v2.yaml
+++ b/website/openapi_v2.yaml
@@ -4884,8 +4884,7 @@ paths:
                     description: UUID de la factura
                   folio_number:
                     type: number
-                    nullable: true
-                    description: Folio de la factura
+                    description: Folio de la factura. Se omite si la factura no lo tiene registrado.
                   series:
                     type: string
                     nullable: true


### PR DESCRIPTION
## Summary

Documents the new `GET /v2/invoices/{invoice_id}/payment-summary` endpoint that returns the related-document object ready to be used in a payment complement (complemento de pago): installment from the payment history, previous balance, and the invoice tax breakdown prorated to the paid amount.

- Adds the path operation to both OpenAPI specs (`openapi_v2.yaml` and `openapi_v2.en.yaml`) with parameters, response schema, and error responses.
- Adds a 'Resumen de pago' section to the payment complement guide (`pago.mdx`) with a Node.js example wiring the summary into `related_documents`.

Pairs with the SDK method `invoices.paymentSummary` (facturapi-node#114).
