### PR TITLE
docs(errors): document mcp_connection_read_only

### DIFF
--- a/website/docs/getting-started/errors.mdx
+++ b/website/docs/getting-started/errors.mdx
@@ -115,6 +115,7 @@ Esta lista es la referencia documentada de códigos raíz públicos de la API. P
 | `feature_not_available` | Esta funcionalidad no está disponible para tu organización. |
 | `live_api_key_required` | Esta operación requiere una API key de producción. |
 | `mcp_permission_denied` | No tienes permiso para usar esta herramienta. |
+| `mcp_connection_read_only` | Tu conexión MCP tiene acceso de solo lectura. Reconecta tu cliente MCP y autoriza lectura y escritura para realizar esta acción. |
 | `missing_credentials` | No se proporcionaron credenciales. |
 | `organization_incomplete` | La organización no está configurada para realizar esta operación. |
 | `subscription_required` | Esta operación requiere una suscripción activa. |

--- a/website/i18n/en/docusaurus-plugin-content-docs/current/getting-started/errors.mdx
+++ b/website/i18n/en/docusaurus-plugin-content-docs/current/getting-started/errors.mdx
@@ -115,6 +115,7 @@ This list is the documented reference for public root API codes. We may add new 
 | `feature_not_available` | The feature is not available for the organization. |
 | `live_api_key_required` | The operation requires a live API key. |
 | `mcp_permission_denied` | The caller does not have permission to use this MCP tool. |
+| `mcp_connection_read_only` | Your MCP connection has read-only access. Reconnect your MCP client authorizing read and write access to perform this action. |
 | `missing_credentials` | The request did not include credentials. |
 | `organization_incomplete` | The organization is not fully configured for this operation. |
 | `subscription_required` | The operation requires an active subscription. |


### PR DESCRIPTION
Documents the new public error code `mcp_connection_read_only` (403): the MCP connection was authorized read-only and the operation requires read-write access — the remediation is reconnecting the MCP client authorizing read and write. Added to the Spanish error reference and the English i18n mirror.