### PR TITLE
Guía de uso de Facturapi MCP (es/en)

### DIFF
--- a/website/docs/guides/mcp-server.mdx
+++ b/website/docs/guides/mcp-server.mdx
@@ -1,0 +1,112 @@
+---
+sidebar_position: 9
+---
+
+# Facturapi MCP: usa tu cuenta desde asistentes de IA
+
+Facturapi MCP es un servidor MCP remoto que permite a asistentes y agentes de IA
+(como ChatGPT, Claude u otras plataformas compatibles) consultar y operar tus
+servicios de Facturapi a través de la API oficial, usando lenguaje natural.
+
+El servidor está **incluido sin costo adicional** para los clientes con
+cualquier servicio de Facturapi contratado (API, Facturación Web, E-Receipts,
+Descarga Masiva o la app para Stripe). El asistente solo puede operar **los
+servicios que tienes contratados** y nunca tiene más permisos que tu propia
+cuenta.
+
+## Conectar desde un asistente (OAuth)
+
+La forma más sencilla de usar Facturapi MCP es conectando tu cuenta desde un
+asistente compatible con MCP:
+
+1. Abre tu asistente y añade el servidor **Facturapi** (o usa la URL
+   `https://mcp.facturapi.io/mcp` cuando el cliente lo permita).
+2. Autoriza con tu cuenta de Facturapi. Elige el nivel de acceso:
+   **solo lectura** o **lectura y escritura**.
+3. Si tienes acceso a varias organizaciones, selecciona con cuál quieres
+   trabajar. El asistente puede listarlas y pedirte `organization_id`.
+4. Pide lo que necesites en lenguaje natural, por ejemplo:
+   - *"Muéstrame las facturas de este mes que aún no se han pagado."*
+   - *"Crea una nota de venta por $500 MXN por una consultoría."*
+   - *"Registra un cliente con sus datos fiscales y envíale su enlace de
+     autofactura."*
+   - *"¿Ya se timbró la factura F-123?"*
+
+Puedes revisar y revocar las conexiones autorizadas cuando quieras desde tu
+dashboard, en **Centro de integración → Conexiones OAuth**.
+
+:::note Ambientes
+Por defecto el asistente opera en tu **ambiente live** (producción). Si estás
+probando, indícalo en la conversación (por ejemplo, *"trabaja en modo pruebas"*)
+para operar en test.
+:::
+
+## Para desarrolladores
+
+El endpoint del servidor es:
+
+```
+https://mcp.facturapi.io/mcp
+```
+
+Puedes autenticarte de dos formas:
+
+- **OAuth (multi-organización):** tokens que empiezan con `mcp_`. El servidor
+  expone `list_organizations` y las herramientas requieren `organization_id`.
+- **API key (una organización):** una llave de API (test o live) de tu
+  organización. El servidor opera sobre esa organización y no expone
+  `list_organizations`.
+
+Todas las llamadas a la API de Facturapi incluyen el encabezado
+`x-facturapi-client: MCP`.
+
+Ejemplo de configuración de cliente (ilustrativo):
+
+```json
+{
+  "mcpServers": {
+    "facturapi": {
+      "type": "http",
+      "url": "https://mcp.facturapi.io/mcp",
+      "headers": {
+        "Authorization": "Bearer <TU_API_KEY>"
+      }
+    }
+  }
+}
+```
+
+### Qué puedes hacer
+
+El servidor expone herramientas para los dominios principales de Facturapi:
+
+- Organizaciones: consultar tu organización y su estado de onboarding.
+- Clientes y productos: buscar, crear, actualizar y administrar catálogos.
+- Facturas (CFDI): crear (ingreso, egreso, complementos de pago), consultar,
+  cancelar y descargar representaciones PDF/XML.
+- E-Receipts: emitir notas de venta, enviar enlaces de autofactura y generar
+  facturas globales.
+- Retenciones: administrar complementos de retención.
+- Webhooks: solo en modo API key, para configurar eventos.
+
+Tu asistente lista las herramientas disponibles al conectarse. Las de escritura
+requieren que elijas **lectura y escritura**; con **solo lectura**, el servidor
+rechaza la operación.
+
+## Alcance y permisos
+
+- El asistente solo accede a las organizaciones donde tu usuario tiene
+  permisos y **nunca tiene más permisos que tu cuenta**.
+- Solo puede operar los **servicios que tienes contratados**. Si intenta una
+  operación que tu plan no incluye, la API responde con un error claro
+  (por ejemplo, `402` cuando no hay una suscripción activa).
+- Elige **solo lectura** o **lectura y escritura** al conectar, y revoca el
+  acceso cuando quieras desde el Centro de integración.
+
+## Referencias
+
+- Metadatos de descubrimiento:
+  `https://mcp.facturapi.io/.well-known/mcp/server.json`
+- Metadatos OAuth del recurso protegido:
+  `https://mcp.facturapi.io/.well-known/oauth-protected-resource`
+- Salud del servicio: `https://mcp.facturapi.io/health`

--- a/website/docs/guides/mcp-server.mdx
+++ b/website/docs/guides/mcp-server.mdx
@@ -9,11 +9,10 @@ Facturapi MCP es un servidor MCP remoto que permite a asistentes de IA
 (como ChatGPT, Claude u otras plataformas compatibles) consultar y operar tus
 servicios de Facturapi a través de la API oficial, usando lenguaje natural.
 
-El servidor está **incluido sin costo adicional** para los clientes con
-cualquier servicio de Facturapi contratado (API, Facturación Web, E-Receipts,
-Descarga Masiva o la app para Stripe). El asistente solo puede operar **los
-servicios que tienes contratados** y nunca tiene más permisos que tu propia
-cuenta.
+Para usarlo necesitas tener contratada la **Licencia API** de Facturapi: el
+servidor está **incluido sin costo adicional** con ella. El asistente solo puede
+operar **los servicios que tienes contratados** y nunca tiene más permisos que
+tu propia cuenta.
 
 ## Cómo conectarte
 

--- a/website/docs/guides/mcp-server.mdx
+++ b/website/docs/guides/mcp-server.mdx
@@ -14,10 +14,17 @@ Descarga Masiva o la app para Stripe). El asistente solo puede operar **los
 servicios que tienes contratados** y nunca tiene más permisos que tu propia
 cuenta.
 
-## Conectar desde un asistente (OAuth)
+## Cómo conectarte
 
-La forma más sencilla de usar Facturapi MCP es conectando tu cuenta desde un
-asistente compatible con MCP:
+El endpoint del servidor es:
+
+```
+https://mcp.facturapi.io/mcp
+```
+
+Hay dos formas de autenticarte, y las dos exponen las mismas herramientas.
+
+### Con OAuth (desde tu asistente)
 
 1. Abre tu asistente y añade el servidor **Facturapi** (o usa la URL
    `https://mcp.facturapi.io/mcp` cuando el cliente lo permita).
@@ -42,26 +49,15 @@ probando, indícalo en la conversación (por ejemplo, *"trabaja en modo pruebas"
 para operar en test.
 :::
 
-## Para desarrolladores
+### Con una API key (desde tu código)
 
-El endpoint del servidor es:
-
-```
-https://mcp.facturapi.io/mcp
-```
-
-Puedes autenticarte de dos formas:
-
-- **OAuth (multi-organización):** tokens que empiezan con `mcp_`. El servidor
-  expone `list_organizations` y las herramientas requieren `organization_id`.
-- **API key (una organización):** una llave de API (test o live) de tu
-  organización. El servidor opera sobre esa organización y no expone
-  `list_organizations`.
+Usa una llave de API (test o live) de tu organización. El servidor opera sobre
+esa organización y no expone `list_organizations`.
 
 Todas las llamadas a la API de Facturapi incluyen el encabezado
 `x-facturapi-client: MCP`.
 
-Ejemplo de configuración de cliente en modo API key (ilustrativo):
+Ejemplo de configuración de cliente (ilustrativo):
 
 ```json
 {
@@ -77,7 +73,7 @@ Ejemplo de configuración de cliente en modo API key (ilustrativo):
 }
 ```
 
-### Qué puedes hacer
+## Qué puedes hacer
 
 El servidor expone herramientas para los dominios principales de Facturapi:
 
@@ -91,8 +87,9 @@ El servidor expone herramientas para los dominios principales de Facturapi:
 - Webhooks: solo en modo API key, para configurar eventos.
 
 Tu asistente lista las herramientas disponibles al conectarse. Las de escritura
-requieren que elijas **lectura y escritura**; con **solo lectura**, el servidor
-rechaza la operación.
+requieren **lectura y escritura** si conectas con OAuth; con **solo lectura**,
+el servidor rechaza la operación. Una API key opera con los permisos de su
+organización.
 
 ## Alcance y permisos
 
@@ -100,9 +97,6 @@ rechaza la operación.
   permisos y **nunca tiene más permisos que tu cuenta**.
 - Solo puede operar los **servicios que tienes contratados**: si intenta una
   operación que tu plan no incluye, no se realiza.
-- Elige **solo lectura** o **lectura y escritura** al conectar, y revoca el
-  acceso cuando quieras desde el
-  [Centro de integración](https://dashboard.facturapi.io/integration/oauth).
 
 ## Referencias
 

--- a/website/docs/guides/mcp-server.mdx
+++ b/website/docs/guides/mcp-server.mdx
@@ -32,8 +32,9 @@ asistente compatible con MCP:
      autofactura."*
    - *"¿Ya se timbró la factura F-123?"*
 
-Puedes revisar y revocar las conexiones autorizadas cuando quieras desde tu
-dashboard, en **Centro de integración → Conexiones OAuth**.
+Puedes revisar y revocar las conexiones autorizadas cuando quieras desde el
+[Centro de integración](https://dashboard.facturapi.io/integration/oauth) de tu
+dashboard.
 
 :::note Ambientes
 Por defecto el asistente opera en tu **ambiente live** (producción). Si estás
@@ -101,7 +102,8 @@ rechaza la operación.
   operación que tu plan no incluye, la API responde con un error claro
   (por ejemplo, `402` cuando no hay una suscripción activa).
 - Elige **solo lectura** o **lectura y escritura** al conectar, y revoca el
-  acceso cuando quieras desde el Centro de integración.
+  acceso cuando quieras desde el
+  [Centro de integración](https://dashboard.facturapi.io/integration/oauth).
 
 ## Referencias
 

--- a/website/docs/guides/mcp-server.mdx
+++ b/website/docs/guides/mcp-server.mdx
@@ -23,8 +23,8 @@ asistente compatible con MCP:
    `https://mcp.facturapi.io/mcp` cuando el cliente lo permita).
 2. Autoriza con tu cuenta de Facturapi. Elige el nivel de acceso:
    **solo lectura** o **lectura y escritura**.
-3. Si tienes acceso a varias organizaciones, selecciona con cuál quieres
-   trabajar. El asistente puede listarlas y pedirte `organization_id`.
+3. Si tienes acceso a varias organizaciones, el asistente te preguntará en cuál
+   quieres trabajar. Solo necesitas nombrarla.
 4. Pide lo que necesites en lenguaje natural, por ejemplo:
    - *"Muéstrame las facturas de este mes que aún no se han pagado."*
    - *"Crea una nota de venta por $500 MXN por una consultoría."*

--- a/website/docs/guides/mcp-server.mdx
+++ b/website/docs/guides/mcp-server.mdx
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 9
+sidebar_label: Facturapi MCP
 ---
 
 # Facturapi MCP: usa tu cuenta desde asistentes de IA

--- a/website/docs/guides/mcp-server.mdx
+++ b/website/docs/guides/mcp-server.mdx
@@ -4,7 +4,7 @@ sidebar_position: 9
 
 # Facturapi MCP: usa tu cuenta desde asistentes de IA
 
-Facturapi MCP es un servidor MCP remoto que permite a asistentes y agentes de IA
+Facturapi MCP es un servidor MCP remoto que permite a asistentes de IA
 (como ChatGPT, Claude u otras plataformas compatibles) consultar y operar tus
 servicios de Facturapi a través de la API oficial, usando lenguaje natural.
 
@@ -61,7 +61,7 @@ Puedes autenticarte de dos formas:
 Todas las llamadas a la API de Facturapi incluyen el encabezado
 `x-facturapi-client: MCP`.
 
-Ejemplo de configuración de cliente (ilustrativo):
+Ejemplo de configuración de cliente en modo API key (ilustrativo):
 
 ```json
 {
@@ -98,9 +98,8 @@ rechaza la operación.
 
 - El asistente solo accede a las organizaciones donde tu usuario tiene
   permisos y **nunca tiene más permisos que tu cuenta**.
-- Solo puede operar los **servicios que tienes contratados**. Si intenta una
-  operación que tu plan no incluye, la API responde con un error claro
-  (por ejemplo, `402` cuando no hay una suscripción activa).
+- Solo puede operar los **servicios que tienes contratados**: si intenta una
+  operación que tu plan no incluye, no se realiza.
 - Elige **solo lectura** o **lectura y escritura** al conectar, y revoca el
   acceso cuando quieras desde el
   [Centro de integración](https://dashboard.facturapi.io/integration/oauth).

--- a/website/docs/guides/mcp-server.mdx
+++ b/website/docs/guides/mcp-server.mdx
@@ -36,11 +36,9 @@ Puedes revisar y revocar las conexiones autorizadas cuando quieras desde el
 [Centro de integración](https://dashboard.facturapi.io/integration/oauth) de tu
 dashboard.
 
-:::note Ambientes
-Por defecto el asistente opera en tu **ambiente live** (producción). Si estás
-probando, indícalo en la conversación (por ejemplo, *"trabaja en modo pruebas"*)
-para operar en test.
-:::
+**Ambientes:** por defecto el asistente opera en tu **ambiente live**
+(producción). Si estás probando, indícalo en la conversación (por ejemplo,
+*"trabaja en modo pruebas"*) para operar en test.
 
 ## Para desarrolladores
 

--- a/website/docs/guides/mcp-server.mdx
+++ b/website/docs/guides/mcp-server.mdx
@@ -36,9 +36,11 @@ Puedes revisar y revocar las conexiones autorizadas cuando quieras desde el
 [Centro de integración](https://dashboard.facturapi.io/integration/oauth) de tu
 dashboard.
 
-**Ambientes:** por defecto el asistente opera en tu **ambiente live**
-(producción). Si estás probando, indícalo en la conversación (por ejemplo,
-*"trabaja en modo pruebas"*) para operar en test.
+:::note[Ambientes]
+Por defecto el asistente opera en tu **ambiente live** (producción). Si estás
+probando, indícalo en la conversación (por ejemplo, *"trabaja en modo pruebas"*)
+para operar en test.
+:::
 
 ## Para desarrolladores
 

--- a/website/i18n/en/docusaurus-plugin-content-docs/current/guides/mcp-server.mdx
+++ b/website/i18n/en/docusaurus-plugin-content-docs/current/guides/mcp-server.mdx
@@ -1,0 +1,110 @@
+---
+sidebar_position: 9
+---
+
+# Facturapi MCP: use your account from AI assistants
+
+Facturapi MCP is a remote MCP server that lets AI assistants and agents
+(ChatGPT, Claude, or other compatible platforms) query and operate your
+Facturapi services through the official API, in natural language.
+
+The server is **included at no extra cost** for customers with any active
+Facturapi service (API, Web Invoicing, E-Receipts, automatic SAT downloads, or
+the Stripe app). The assistant can only operate **the services you have
+contracted** and never has more permissions than your own account.
+
+## Connect from an assistant (OAuth)
+
+The easiest way to use Facturapi MCP is to connect your account from an
+MCP-compatible assistant:
+
+1. Open your assistant and add the **Facturapi** server (or use the URL
+   `https://mcp.facturapi.io/mcp` when the client allows it).
+2. Authorize with your Facturapi account. Choose the access level:
+   **read-only** or **read & write**.
+3. If you have access to several organizations, select the one you want to work
+   with. The assistant can list them and ask you for an `organization_id`.
+4. Ask for what you need in plain language, for example:
+   - *"Show me this month's invoices that haven't been paid yet."*
+   - *"Create a sales receipt for $500 MXN for a consulting service."*
+   - *"Register a customer with their tax information and send them their
+     self-invoicing link."*
+   - *"Has invoice F-123 been stamped already?"*
+
+You can review and revoke authorized connections anytime from your dashboard
+under **Integration Center → OAuth connections**.
+
+:::note Environments
+By default the assistant operates in your **live** environment (production).
+If you are testing, say so in the conversation (for example, *"work in test
+mode"*) to operate in test mode.
+:::
+
+## For developers
+
+The server endpoint is:
+
+```
+https://mcp.facturapi.io/mcp
+```
+
+There are two authentication modes:
+
+- **OAuth (multi-organization):** tokens that start with `mcp_`. The server
+  exposes `list_organizations` and tools require an `organization_id`.
+- **API key (single organization):** one of your organization's API keys (test
+  or live). The server operates on that organization and does not expose
+  `list_organizations`.
+
+All calls to the Facturapi API include the `x-facturapi-client: MCP` header.
+
+Illustrative client configuration:
+
+```json
+{
+  "mcpServers": {
+    "facturapi": {
+      "type": "http",
+      "url": "https://mcp.facturapi.io/mcp",
+      "headers": {
+        "Authorization": "Bearer <YOUR_API_KEY>"
+      }
+    }
+  }
+}
+```
+
+### What you can do
+
+The server exposes tools for Facturapi's main domains:
+
+- Organizations: look up your organization and its onboarding status.
+- Customers and products: search, create, update, and manage catalogs.
+- Invoices (CFDI): create (income, expense, payment complements), query,
+  cancel, and download PDF/XML representations.
+- E-Receipts: issue sales receipts, send self-invoicing links, and generate
+  global invoices.
+- Retentions: manage retention complements.
+- Webhooks: API-key mode only, to configure events.
+
+Your assistant lists the available tools when it connects. Write tools require
+connecting with **read &amp; write**; with **read-only**, the server rejects the
+operation.
+
+## Scope and permissions
+
+- The assistant only reaches the organizations where your user has permissions
+  and **never has more permissions than your account**.
+- It can only operate the **services you have contracted**. If it tries an
+  operation your plan does not include, the API responds with a clear error
+  (for example, `402` when there is no active subscription).
+- Choose **read-only** or **read & write** when connecting, and revoke access
+  anytime from the Integration Center.
+
+## References
+
+- Discovery metadata:
+  `https://mcp.facturapi.io/.well-known/mcp/server.json`
+- OAuth protected resource metadata:
+  `https://mcp.facturapi.io/.well-known/oauth-protected-resource`
+- Service health: `https://mcp.facturapi.io/health`

--- a/website/i18n/en/docusaurus-plugin-content-docs/current/guides/mcp-server.mdx
+++ b/website/i18n/en/docusaurus-plugin-content-docs/current/guides/mcp-server.mdx
@@ -31,8 +31,9 @@ MCP-compatible assistant:
      self-invoicing link."*
    - *"Has invoice F-123 been stamped already?"*
 
-You can review and revoke authorized connections anytime from your dashboard
-under **Integration Center → OAuth connections**.
+You can review and revoke authorized connections anytime from the
+[Integration Center](https://dashboard.facturapi.io/integration/oauth) in your
+dashboard.
 
 :::note Environments
 By default the assistant operates in your **live** environment (production).
@@ -99,7 +100,8 @@ operation.
   operation your plan does not include, the API responds with a clear error
   (for example, `402` when there is no active subscription).
 - Choose **read-only** or **read & write** when connecting, and revoke access
-  anytime from the Integration Center.
+  anytime from the
+  [Integration Center](https://dashboard.facturapi.io/integration/oauth).
 
 ## References
 

--- a/website/i18n/en/docusaurus-plugin-content-docs/current/guides/mcp-server.mdx
+++ b/website/i18n/en/docusaurus-plugin-content-docs/current/guides/mcp-server.mdx
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 9
+sidebar_label: Facturapi MCP
 ---
 
 # Facturapi MCP: use your account from AI assistants

--- a/website/i18n/en/docusaurus-plugin-content-docs/current/guides/mcp-server.mdx
+++ b/website/i18n/en/docusaurus-plugin-content-docs/current/guides/mcp-server.mdx
@@ -13,15 +13,22 @@ Facturapi service (API, Web Invoicing, E-Receipts, automatic SAT downloads, or
 the Stripe app). The assistant can only operate **the services you have
 contracted** and never has more permissions than your own account.
 
-## Connect from an assistant (OAuth)
+## How to connect
 
-The easiest way to use Facturapi MCP is to connect your account from an
-MCP-compatible assistant:
+The server endpoint is:
+
+```
+https://mcp.facturapi.io/mcp
+```
+
+There are two ways to authenticate, and both expose the same tools.
+
+### With OAuth (from your assistant)
 
 1. Open your assistant and add the **Facturapi** server (or use the URL
    `https://mcp.facturapi.io/mcp` when the client allows it).
 2. Authorize with your Facturapi account. Choose the access level:
-   **read-only** or **read & write**.
+   **read-only** or **read &amp; write**.
 3. If you have access to several organizations, the assistant will ask which one
    you want to work with. You only need to name it.
 4. Ask for what you need in plain language, for example:
@@ -41,25 +48,14 @@ If you are testing, say so in the conversation (for example, *"work in test
 mode"*) to operate in test mode.
 :::
 
-## For developers
+### With an API key (from your code)
 
-The server endpoint is:
-
-```
-https://mcp.facturapi.io/mcp
-```
-
-There are two authentication modes:
-
-- **OAuth (multi-organization):** tokens that start with `mcp_`. The server
-  exposes `list_organizations` and tools require an `organization_id`.
-- **API key (single organization):** one of your organization's API keys (test
-  or live). The server operates on that organization and does not expose
-  `list_organizations`.
+Use one of your organization's API keys (test or live). The server operates on
+that organization and does not expose `list_organizations`.
 
 All calls to the Facturapi API include the `x-facturapi-client: MCP` header.
 
-Illustrative client configuration in API key mode:
+Illustrative client configuration:
 
 ```json
 {
@@ -75,7 +71,7 @@ Illustrative client configuration in API key mode:
 }
 ```
 
-### What you can do
+## What you can do
 
 The server exposes tools for Facturapi's main domains:
 
@@ -89,8 +85,8 @@ The server exposes tools for Facturapi's main domains:
 - Webhooks: API-key mode only, to configure events.
 
 Your assistant lists the available tools when it connects. Write tools require
-connecting with **read &amp; write**; with **read-only**, the server rejects the
-operation.
+**read &amp; write** when connecting with OAuth; with **read-only**, the server
+rejects the operation. An API key operates with its organization's permissions.
 
 ## Scope and permissions
 
@@ -98,9 +94,6 @@ operation.
   and **never has more permissions than your account**.
 - It can only operate the **services you have contracted**: if it tries an
   operation your plan does not include, it is not performed.
-- Choose **read-only** or **read & write** when connecting, and revoke access
-  anytime from the
-  [Integration Center](https://dashboard.facturapi.io/integration/oauth).
 
 ## References
 

--- a/website/i18n/en/docusaurus-plugin-content-docs/current/guides/mcp-server.mdx
+++ b/website/i18n/en/docusaurus-plugin-content-docs/current/guides/mcp-server.mdx
@@ -4,7 +4,7 @@ sidebar_position: 9
 
 # Facturapi MCP: use your account from AI assistants
 
-Facturapi MCP is a remote MCP server that lets AI assistants and agents
+Facturapi MCP is a remote MCP server that lets AI assistants
 (ChatGPT, Claude, or other compatible platforms) query and operate your
 Facturapi services through the official API, in natural language.
 
@@ -59,7 +59,7 @@ There are two authentication modes:
 
 All calls to the Facturapi API include the `x-facturapi-client: MCP` header.
 
-Illustrative client configuration:
+Illustrative client configuration in API key mode:
 
 ```json
 {
@@ -96,9 +96,8 @@ operation.
 
 - The assistant only reaches the organizations where your user has permissions
   and **never has more permissions than your account**.
-- It can only operate the **services you have contracted**. If it tries an
-  operation your plan does not include, the API responds with a clear error
-  (for example, `402` when there is no active subscription).
+- It can only operate the **services you have contracted**: if it tries an
+  operation your plan does not include, it is not performed.
 - Choose **read-only** or **read & write** when connecting, and revoke access
   anytime from the
   [Integration Center](https://dashboard.facturapi.io/integration/oauth).

--- a/website/i18n/en/docusaurus-plugin-content-docs/current/guides/mcp-server.mdx
+++ b/website/i18n/en/docusaurus-plugin-content-docs/current/guides/mcp-server.mdx
@@ -35,9 +35,11 @@ You can review and revoke authorized connections anytime from the
 [Integration Center](https://dashboard.facturapi.io/integration/oauth) in your
 dashboard.
 
-**Environments:** by default the assistant operates in your **live** environment
-(production). If you are testing, say so in the conversation (for example,
-*"work in test mode"*) to operate in test mode.
+:::note[Environments]
+By default the assistant operates in your **live** environment (production).
+If you are testing, say so in the conversation (for example, *"work in test
+mode"*) to operate in test mode.
+:::
 
 ## For developers
 

--- a/website/i18n/en/docusaurus-plugin-content-docs/current/guides/mcp-server.mdx
+++ b/website/i18n/en/docusaurus-plugin-content-docs/current/guides/mcp-server.mdx
@@ -22,8 +22,8 @@ MCP-compatible assistant:
    `https://mcp.facturapi.io/mcp` when the client allows it).
 2. Authorize with your Facturapi account. Choose the access level:
    **read-only** or **read & write**.
-3. If you have access to several organizations, select the one you want to work
-   with. The assistant can list them and ask you for an `organization_id`.
+3. If you have access to several organizations, the assistant will ask which one
+   you want to work with. You only need to name it.
 4. Ask for what you need in plain language, for example:
    - *"Show me this month's invoices that haven't been paid yet."*
    - *"Create a sales receipt for $500 MXN for a consulting service."*

--- a/website/i18n/en/docusaurus-plugin-content-docs/current/guides/mcp-server.mdx
+++ b/website/i18n/en/docusaurus-plugin-content-docs/current/guides/mcp-server.mdx
@@ -9,10 +9,10 @@ Facturapi MCP is a remote MCP server that lets AI assistants
 (ChatGPT, Claude, or other compatible platforms) query and operate your
 Facturapi services through the official API, in natural language.
 
-The server is **included at no extra cost** for customers with any active
-Facturapi service (API, Web Invoicing, E-Receipts, automatic SAT downloads, or
-the Stripe app). The assistant can only operate **the services you have
-contracted** and never has more permissions than your own account.
+To use it you need an active Facturapi **API License**: the server is
+**included at no extra cost** with it. The assistant can only operate **the
+services you have contracted** and never has more permissions than your own
+account.
 
 ## How to connect
 

--- a/website/i18n/en/docusaurus-plugin-content-docs/current/guides/mcp-server.mdx
+++ b/website/i18n/en/docusaurus-plugin-content-docs/current/guides/mcp-server.mdx
@@ -35,11 +35,9 @@ You can review and revoke authorized connections anytime from the
 [Integration Center](https://dashboard.facturapi.io/integration/oauth) in your
 dashboard.
 
-:::note Environments
-By default the assistant operates in your **live** environment (production).
-If you are testing, say so in the conversation (for example, *"work in test
-mode"*) to operate in test mode.
-:::
+**Environments:** by default the assistant operates in your **live** environment
+(production). If you are testing, say so in the conversation (for example,
+*"work in test mode"*) to operate in test mode.
 
 ## For developers
 

--- a/website/static/llms.txt
+++ b/website/static/llms.txt
@@ -1,0 +1,37 @@
+# Facturapi
+
+> Documentación de Facturapi: API v2, guías de facturación electrónica (CFDI) y complementos del SAT para México.
+
+## Empezar
+
+- [Introducción](https://docs.facturapi.io/docs/intro/): qué es Facturapi y qué puedes construir.
+- [Inicio rápido](https://docs.facturapi.io/docs/quickstart/): tu primer CFDI en pocos minutos.
+- [Instalación de SDKs](https://docs.facturapi.io/docs/getting-started/install/): clientes oficiales para cada lenguaje.
+- [Autenticación](https://docs.facturapi.io/docs/getting-started/authenticate/): llaves por organización y ambientes test/live.
+- [Conceptos](https://docs.facturapi.io/docs/getting-started/concepts/): organizaciones, documentos y catálogos del SAT.
+- [Manejo de fechas](https://docs.facturapi.io/docs/getting-started/dates/): zonas horarias y formatos aceptados.
+- [Límites de uso](https://docs.facturapi.io/docs/getting-started/rate-limits/)
+- [Errores](https://docs.facturapi.io/docs/getting-started/errors/): códigos y significados.
+
+## Referencia de la API
+
+- [API v2 (español)](https://docs.facturapi.io/api-es/)
+- [API v2 (English)](https://docs.facturapi.io/api-en/)
+
+## Guías
+
+- [Clientes](https://docs.facturapi.io/docs/guides/customers/)
+- [Productos](https://docs.facturapi.io/docs/guides/products/)
+- [Facturas (CFDI)](https://docs.facturapi.io/docs/guides/invoices/)
+- [Recibos (E-Receipts)](https://docs.facturapi.io/docs/guides/receipts/)
+- [Autofactura](https://docs.facturapi.io/docs/guides/self-invoice/)
+- [Borradores](https://docs.facturapi.io/docs/guides/drafts/)
+- [Usuarios y permisos](https://docs.facturapi.io/docs/guides/team-management/)
+- [Facturapi MCP](https://docs.facturapi.io/docs/guides/mcp-server/)
+
+## Otros sitios
+
+- [Sitio principal](https://www.facturapi.io)
+- [Facturapi MCP](https://mcp.facturapi.io)
+
+La misma documentación está disponible en inglés bajo `/en/` (por ejemplo, https://docs.facturapi.io/en/docs/quickstart/).

--- a/website/static/robots.txt
+++ b/website/static/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://docs.facturapi.io/sitemap.xml


### PR DESCRIPTION
## Summary

New guide in the **Guías** section (ES + EN mirror): *Facturapi MCP: usa tu cuenta desde asistentes de IA*.

Covers:
- What Facturapi MCP is and the scope model (access = contracted services).
- Connecting from an assistant via OAuth (read-only / read & write) and managing connections from the Integration Center.
- Developer quickstart: endpoint `https://mcp.facturapi.io/mcp`, OAuth (`mcp_`) vs API key modes, live-mode default, and an illustrative client config.
- What you can ask for, by domain, and how the assistant lists its available tools on connect.
- Scope/permissions model and references (discovery, OAuth metadata, health).
