### PR TITLE
Document the signed download URL endpoints

### DIFF
--- a/website/docs/getting-started/errors.mdx
+++ b/website/docs/getting-started/errors.mdx
@@ -301,6 +301,7 @@ Estos códigos describen errores de información fiscal validados por Facturapi.
 | Código | Descripción |
 | --- | --- |
 | `invoice_cancellation_in_progress` | La factura tiene una solicitud de cancelación pendiente. |
+| `invoice_cancellation_receipt_external` | El acuse sólo está disponible para CFDI cuya cancelación se solicitó mediante Facturapi. |
 | `invoice_cancellation_receipt_unavailable` | El acuse de cancelación no está disponible. |
 | `invoice_cancellation_failed` | No se pudo cancelar la factura. |
 | `invoice_cancellation_not_allowed` | La cancelación de la factura no está permitida. |

--- a/website/docs/guides/invoices/cancelaciones.mdx
+++ b/website/docs/guides/invoices/cancelaciones.mdx
@@ -158,7 +158,9 @@ Facturapi consulta periódicamente el SAT y actualiza `cancellation_status`. Pue
 
 ## Acuse de cancelación y verificación
 
-Cuando la cancelación es aceptada, puedes descargar el acuse en XML o PDF desde el endpoint de [Cancellation receipt](/api/#tag/invoice/operation/downloadCancellationReceiptXml). También puedes validar el CFDI con `verification_url`.
+Cuando solicitas la cancelación mediante Facturapi, puedes descargar el acuse emitido por el SAT en XML o PDF desde el endpoint de [Cancellation receipt](/api/#tag/invoice/operation/downloadCancellationReceiptXml). El acuse demuestra el resultado inmediato de la solicitud, pero no necesariamente que el CFDI ya esté cancelado: confirma el desenlace con `status`, `cancellation_status` o `verification_url`.
+
+Facturapi sólo puede recuperar acuses de solicitudes enviadas mediante su servicio. Para cancelaciones realizadas externamente, valida el estado actual del CFDI con `verification_url`.
 
 <Tabs groupId="receiptExamples">
 <TabItem value="curl" label="cURL" default>

--- a/website/i18n/en/docusaurus-plugin-content-docs/current/getting-started/errors.mdx
+++ b/website/i18n/en/docusaurus-plugin-content-docs/current/getting-started/errors.mdx
@@ -301,6 +301,7 @@ These codes describe tax-information errors validated by Facturapi. When a custo
 | Code | Description |
 | --- | --- |
 | `invoice_cancellation_in_progress` | The invoice already has a pending cancellation request. |
+| `invoice_cancellation_receipt_external` | The receipt is only available for CFDI cancellation requests submitted through Facturapi. |
 | `invoice_cancellation_receipt_unavailable` | The cancellation receipt is not available. |
 | `invoice_cancellation_failed` | The invoice could not be canceled. |
 | `invoice_cancellation_not_allowed` | Invoice cancellation is not allowed. |

--- a/website/i18n/en/docusaurus-plugin-content-docs/current/guides/invoices/cancelaciones.mdx
+++ b/website/i18n/en/docusaurus-plugin-content-docs/current/guides/invoices/cancelaciones.mdx
@@ -144,7 +144,9 @@ Facturapi periodically checks the SAT and updates `cancellation_status`. You can
 
 ## Cancellation receipt and verification
 
-When the cancellation is accepted, you can download the cancellation receipt in XML or PDF from the [Cancellation receipt](/api/#tag/invoice/operation/downloadCancellationReceiptXml) endpoint. You can also validate the CFDI using `verification_url`.
+When you submit the cancellation through Facturapi, you can download the SAT receipt in XML or PDF from the [Cancellation receipt](/api/#tag/invoice/operation/downloadCancellationReceiptXml) endpoint. The receipt proves the immediate result of the request, but does not necessarily mean that the CFDI is already canceled: confirm the outcome using `status`, `cancellation_status`, or `verification_url`.
+
+Facturapi can only retrieve receipts for requests submitted through its service. For cancellations performed externally, validate the current CFDI status using `verification_url`.
 
 <Tabs groupId="receiptExamples">
 <TabItem value="curl" label="cURL" default>

--- a/website/openapi_v2.en.yaml
+++ b/website/openapi_v2.en.yaml
@@ -11638,9 +11638,8 @@ paths:
             import Facturapi from 'facturapi';
 
             const facturapi = new Facturapi('sk_test_API_KEY');
-            const download = await facturapi.invoices.getDownloadUrl(
-              '58e93bd8e86eb318b019743d',
-              'pdf'
+            const download = await facturapi.invoices.downloadPdfUrl(
+              '58e93bd8e86eb318b019743d'
             );
 
             console.log(download.url, download.expires_at);
@@ -11705,9 +11704,8 @@ paths:
             import Facturapi from 'facturapi';
 
             const facturapi = new Facturapi('sk_test_API_KEY');
-            const download = await facturapi.invoices.getCancellationReceiptDownloadUrl(
-              '58e93bd8e86eb318b019743d',
-              'pdf'
+            const download = await facturapi.invoices.downloadCancellationReceiptPdfUrl(
+              '58e93bd8e86eb318b019743d'
             );
 
             console.log(download.url, download.expires_at);
@@ -11769,7 +11767,7 @@ paths:
             import Facturapi from 'facturapi';
 
             const facturapi = new Facturapi('sk_test_API_KEY');
-            const download = await facturapi.receipts.getDownloadUrl(
+            const download = await facturapi.receipts.downloadPdfUrl(
               '58e93bd8e86eb318b019743d'
             );
 
@@ -11823,9 +11821,8 @@ paths:
             import Facturapi from 'facturapi';
 
             const facturapi = new Facturapi('sk_test_API_KEY');
-            const download = await facturapi.retentions.getDownloadUrl(
-              '58e93bd8e86eb318b019743d',
-              'pdf'
+            const download = await facturapi.retentions.downloadPdfUrl(
+              '58e93bd8e86eb318b019743d'
             );
 
             console.log(download.url, download.expires_at);

--- a/website/openapi_v2.en.yaml
+++ b/website/openapi_v2.en.yaml
@@ -4599,7 +4599,7 @@ paths:
       tags:
         - invoice
       summary: Cancellation receipt
-      description: Download the cancellation receipt of a canceled invoice in an xml or pdf file.
+      description: Download the XML or PDF receipt issued by SAT when a cancellation request is submitted through Facturapi. The receipt contains the immediate request result and does not necessarily prove that the CFDI is already canceled; check the invoice status to confirm the outcome.
       x-codeSamples:
         - lang: Bash
           label: cURL
@@ -11817,7 +11817,7 @@ paths:
         - invoice
       summary: Get cancellation receipt download URL
       description: |
-        Returns a temporary URL to download the cancellation receipt of an invoice in XML or PDF, without the file travelling through your server.
+        Returns a temporary URL to download the XML or PDF receipt issued by SAT when a cancellation request is submitted through Facturapi, without the file travelling through your server. The receipt contains the immediate request result and does not necessarily prove that the CFDI is already canceled; check the invoice status to confirm the outcome.
 
         The URL grants access to that one file while it is valid: treat it as a credential and do not store it.
       x-codeSamples:

--- a/website/openapi_v2.en.yaml
+++ b/website/openapi_v2.en.yaml
@@ -3884,6 +3884,58 @@ paths:
           $ref: "#/components/responses/RateLimited"
         "500":
           $ref: "#/components/responses/UnexpectedError"
+  /invoices/zip-requests/{id}/download-url:
+    get:
+      operationId: getInvoiceZipRequestDownloadUrl
+      tags:
+        - invoice
+      summary: Get monthly ZIP download URL
+      description: |
+        Returns a temporary URL for downloading the ZIP of a finished request without the file travelling through your server.
+
+        The URL grants access to that one file while it is valid: treat it as a credential and do not store it. Requires a live-mode organization API key, an active subscription, and permission to read invoices.
+      x-codeSamples:
+        - lang: Bash
+          label: cURL
+          source: |
+            curl https://www.facturapi.io/v2/invoices/zip-requests/66b0f0000000000000000000/download-url \
+              -H "Authorization: Bearer sk_live_API_KEY"
+        - lang: JavaScript
+          label: Node.js
+          source: |
+            import Facturapi from 'facturapi';
+
+            const facturapi = new Facturapi('sk_live_API_KEY');
+            const download = await facturapi.invoices.downloadZipRequestUrl(
+              '66b0f0000000000000000000'
+            );
+
+            console.log(download.url, download.expires_at);
+      parameters:
+        - $ref: "#/components/parameters/InvoiceZipRequestId"
+      security:
+        - "SecretLiveKey": []
+      responses:
+        "200":
+          description: Temporary download URL for the generated ZIP file.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SignedDownloadUrl"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthenticated"
+        "402":
+          $ref: "#/components/responses/InvoiceZipRequestAccessRequired"
+        "404":
+          $ref: "#/components/responses/InvoiceZipRequestNotFound"
+        "409":
+          $ref: "#/components/responses/InvoiceZipRequestNotReady"
+        "429":
+          $ref: "#/components/responses/RateLimited"
+        "500":
+          $ref: "#/components/responses/UnexpectedError"
   /invoices/preview/pdf:
     post:
       operationId: previewInvoicePdf

--- a/website/openapi_v2.en.yaml
+++ b/website/openapi_v2.en.yaml
@@ -11663,6 +11663,10 @@ paths:
           $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthenticated"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/Conflict"
         "429":
           $ref: "#/components/responses/RateLimited"
         "500":
@@ -11713,6 +11717,8 @@ paths:
           $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthenticated"
+        "404":
+          $ref: "#/components/responses/NotFound"
         "429":
           $ref: "#/components/responses/RateLimited"
         "500":
@@ -11754,6 +11760,8 @@ paths:
           $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthenticated"
+        "404":
+          $ref: "#/components/responses/NotFound"
         "429":
           $ref: "#/components/responses/RateLimited"
         "500":
@@ -11805,6 +11813,10 @@ paths:
           $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthenticated"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/Conflict"
         "429":
           $ref: "#/components/responses/RateLimited"
         "500":
@@ -12400,6 +12412,11 @@ components:
     SignedDownloadUrl:
       type: object
       description: Temporary download URL for a file.
+      required:
+        - url
+        - expires_at
+        - content_type
+        - filename
       properties:
         url:
           type: string

--- a/website/openapi_v2.en.yaml
+++ b/website/openapi_v2.en.yaml
@@ -11632,6 +11632,18 @@ paths:
           source: |
             curl https://www.facturapi.io/v2/invoices/58e93bd8e86eb318b019743d/download-url/pdf \
               -H "Authorization: Bearer sk_test_API_KEY"
+        - lang: JavaScript
+          label: Node.js
+          source: |
+            import Facturapi from 'facturapi';
+
+            const facturapi = new Facturapi('sk_test_API_KEY');
+            const download = await facturapi.invoices.getDownloadUrl(
+              '58e93bd8e86eb318b019743d',
+              'pdf'
+            );
+
+            console.log(download.url, download.expires_at);
       parameters:
         - in: path
           name: invoice_id
@@ -11687,6 +11699,18 @@ paths:
           source: |
             curl https://www.facturapi.io/v2/invoices/58e93bd8e86eb318b019743d/cancellation_receipt/download-url/pdf \
               -H "Authorization: Bearer sk_test_API_KEY"
+        - lang: JavaScript
+          label: Node.js
+          source: |
+            import Facturapi from 'facturapi';
+
+            const facturapi = new Facturapi('sk_test_API_KEY');
+            const download = await facturapi.invoices.getCancellationReceiptDownloadUrl(
+              '58e93bd8e86eb318b019743d',
+              'pdf'
+            );
+
+            console.log(download.url, download.expires_at);
       parameters:
         - in: path
           name: invoice_id
@@ -11739,6 +11763,17 @@ paths:
           source: |
             curl https://www.facturapi.io/v2/receipts/58e93bd8e86eb318b019743d/download-url/pdf \
               -H "Authorization: Bearer sk_test_API_KEY"
+        - lang: JavaScript
+          label: Node.js
+          source: |
+            import Facturapi from 'facturapi';
+
+            const facturapi = new Facturapi('sk_test_API_KEY');
+            const download = await facturapi.receipts.getDownloadUrl(
+              '58e93bd8e86eb318b019743d'
+            );
+
+            console.log(download.url, download.expires_at);
       parameters:
         - in: path
           name: receipt_id
@@ -11782,6 +11817,18 @@ paths:
           source: |
             curl https://www.facturapi.io/v2/retentions/58e93bd8e86eb318b019743d/download-url/pdf \
               -H "Authorization: Bearer sk_test_API_KEY"
+        - lang: JavaScript
+          label: Node.js
+          source: |
+            import Facturapi from 'facturapi';
+
+            const facturapi = new Facturapi('sk_test_API_KEY');
+            const download = await facturapi.retentions.getDownloadUrl(
+              '58e93bd8e86eb318b019743d',
+              'pdf'
+            );
+
+            console.log(download.url, download.expires_at);
       parameters:
         - in: path
           name: retention_id

--- a/website/openapi_v2.en.yaml
+++ b/website/openapi_v2.en.yaml
@@ -4110,6 +4110,43 @@ paths:
           $ref: "#/components/responses/RateLimited"
         "500":
           $ref: "#/components/responses/UnexpectedError"
+  /invoices/preview/pdf/download-url:
+    post:
+      operationId: previewInvoicePdfUrl
+      tags:
+        - invoice
+      summary: Get invoice PDF preview URL
+      description: Returns a temporary URL for an unstamped invoice PDF preview.
+      x-codeSamples:
+        - lang: JavaScript
+          label: Node.js
+          source: |
+            const download = await facturapi.invoices.previewPdfUrl({
+              customer: 'cus_123',
+              items: [{ product: 'prod_123' }],
+              payment_form: '06'
+            });
+            console.log(download.url, download.expires_at);
+      requestBody:
+        $ref: "#/components/requestBodies/InvoiceCreate"
+      security:
+        - "SecretLiveKey": []
+        - "SecretTestKey": []
+      responses:
+        "200":
+          description: Temporary download URL for the PDF preview.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SignedDownloadUrl"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthenticated"
+        "429":
+          $ref: "#/components/responses/RateLimited"
+        "500":
+          $ref: "#/components/responses/UnexpectedError"
   /invoices/{invoice_id}:
     get:
       operationId: getInvoice
@@ -6333,6 +6370,45 @@ paths:
           $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthenticated"
+        "500":
+          $ref: "#/components/responses/UnexpectedError"
+  /receipts/to-invoice/preview/download-url:
+    post:
+      operationId: previewToInvoiceFromReceiptsUrl
+      tags:
+        - receipt
+      summary: Get receipts invoice preview URL
+      description: Returns a temporary URL for the PDF preview of an invoice built from the selected receipts.
+      x-codeSamples:
+        - lang: JavaScript
+          label: Node.js
+          source: |
+            const download = await facturapi.receipts.previewToInvoicePdfUrl({
+              keys: ['ticket_1001', 'ticket_1002'],
+              customer: 'cus_123',
+              use: 'G03'
+            });
+            console.log(download.url, download.expires_at);
+      requestBody:
+        $ref: "#/components/requestBodies/ReceiptPreviewToInvoice"
+      security:
+        - "SecretLiveKey": []
+        - "SecretTestKey": []
+      responses:
+        "200":
+          description: Temporary download URL for the PDF preview.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SignedDownloadUrl"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthenticated"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "429":
+          $ref: "#/components/responses/RateLimited"
         "500":
           $ref: "#/components/responses/UnexpectedError"
   /receipts/global-invoice:

--- a/website/openapi_v2.en.yaml
+++ b/website/openapi_v2.en.yaml
@@ -11616,6 +11616,199 @@ paths:
           $ref: "#/components/responses/RateLimited"
         "500":
           $ref: "#/components/responses/UnexpectedError"
+  /invoices/{invoice_id}/download-url/{format}:
+    get:
+      operationId: getInvoiceDownloadUrl
+      tags:
+        - invoice
+      summary: Get download URL
+      description: |
+        Returns a temporary URL to download the invoice in PDF, XML, or both in a ZIP file, without the file travelling through your server.
+
+        The URL grants access to that one file while it is valid: treat it as a credential and do not store it.
+      x-codeSamples:
+        - lang: Bash
+          label: cURL
+          source: |
+            curl https://www.facturapi.io/v2/invoices/58e93bd8e86eb318b019743d/download-url/pdf \
+              -H "Authorization: Bearer sk_test_API_KEY"
+      parameters:
+        - in: path
+          name: invoice_id
+          schema:
+            type: string
+          required: true
+          description: ID of the object to download
+        - in: path
+          name: format
+          schema:
+            type: string
+            enum:
+              - pdf
+              - xml
+              - zip
+          required: true
+          description: Format of the file to download
+      security:
+        - "SecretLiveKey": []
+        - "SecretTestKey": []
+      responses:
+        "200":
+          description: Temporary download URL for the CFDI in the requested format
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SignedDownloadUrl"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthenticated"
+        "429":
+          $ref: "#/components/responses/RateLimited"
+        "500":
+          $ref: "#/components/responses/UnexpectedError"
+  /invoices/{invoice_id}/cancellation_receipt/download-url/{format}:
+    get:
+      operationId: getCancellationReceiptDownloadUrl
+      tags:
+        - invoice
+      summary: Get cancellation receipt download URL
+      description: |
+        Returns a temporary URL to download the cancellation receipt of an invoice in XML or PDF, without the file travelling through your server.
+
+        The URL grants access to that one file while it is valid: treat it as a credential and do not store it.
+      x-codeSamples:
+        - lang: Bash
+          label: cURL
+          source: |
+            curl https://www.facturapi.io/v2/invoices/58e93bd8e86eb318b019743d/cancellation_receipt/download-url/pdf \
+              -H "Authorization: Bearer sk_test_API_KEY"
+      parameters:
+        - in: path
+          name: invoice_id
+          schema:
+            type: string
+          required: true
+          description: ID of the object to download
+        - in: path
+          name: format
+          schema:
+            type: string
+            enum:
+              - xml
+              - pdf
+          required: true
+          description: Format of the cancellation receipt
+      security:
+        - "SecretLiveKey": []
+        - "SecretTestKey": []
+      responses:
+        "200":
+          description: Temporary download URL for the cancellation receipt in the requested format
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SignedDownloadUrl"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthenticated"
+        "429":
+          $ref: "#/components/responses/RateLimited"
+        "500":
+          $ref: "#/components/responses/UnexpectedError"
+  /receipts/{receipt_id}/download-url/pdf:
+    get:
+      operationId: getReceiptDownloadUrl
+      tags:
+        - receipt
+      summary: Get download URL
+      description: |
+        Returns a temporary URL to download the receipt in PDF, without the file travelling through your server.
+
+        The URL grants access to that one file while it is valid: treat it as a credential and do not store it.
+      x-codeSamples:
+        - lang: Bash
+          label: cURL
+          source: |
+            curl https://www.facturapi.io/v2/receipts/58e93bd8e86eb318b019743d/download-url/pdf \
+              -H "Authorization: Bearer sk_test_API_KEY"
+      parameters:
+        - in: path
+          name: receipt_id
+          schema:
+            type: string
+          required: true
+          description: ID of the object to download
+      security:
+        - "SecretLiveKey": []
+        - "SecretTestKey": []
+      responses:
+        "200":
+          description: Temporary download URL for the receipt in PDF
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SignedDownloadUrl"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthenticated"
+        "429":
+          $ref: "#/components/responses/RateLimited"
+        "500":
+          $ref: "#/components/responses/UnexpectedError"
+  /retentions/{retention_id}/download-url/{format}:
+    get:
+      operationId: getRetentionDownloadUrl
+      tags:
+        - retention
+      summary: Get download URL
+      description: |
+        Returns a temporary URL to download the retention in PDF, XML, or both in a ZIP file, without the file travelling through your server.
+
+        The URL grants access to that one file while it is valid: treat it as a credential and do not store it.
+      x-codeSamples:
+        - lang: Bash
+          label: cURL
+          source: |
+            curl https://www.facturapi.io/v2/retentions/58e93bd8e86eb318b019743d/download-url/pdf \
+              -H "Authorization: Bearer sk_test_API_KEY"
+      parameters:
+        - in: path
+          name: retention_id
+          schema:
+            type: string
+          required: true
+          description: ID of the object to download
+        - in: path
+          name: format
+          schema:
+            type: string
+            enum:
+              - pdf
+              - xml
+              - zip
+          required: true
+          description: Format of the file to download
+      security:
+        - "SecretLiveKey": []
+        - "SecretTestKey": []
+      responses:
+        "200":
+          description: Temporary download URL for the retention in the requested format
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SignedDownloadUrl"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthenticated"
+        "429":
+          $ref: "#/components/responses/RateLimited"
+        "500":
+          $ref: "#/components/responses/UnexpectedError"
 x-webhooks:
   "Global invoice created":
     post:
@@ -12204,6 +12397,25 @@ components:
       description: Number from 1 to 100 representing the maximum amount of results to return for pagination purposes.
 
   schemas:
+    SignedDownloadUrl:
+      type: object
+      description: Temporary download URL for a file.
+      properties:
+        url:
+          type: string
+          description: Download URL. It grants access to the file while it is valid.
+        expires_at:
+          type: string
+          format: date-time
+          description: Moment at which the URL stops working.
+        content_type:
+          type: string
+          description: Content type of the file.
+          example: application/pdf
+        filename:
+          type: string
+          description: Suggested file name.
+          example: invoice.pdf
     RelatedResourceMessage:
       type: object
       properties:

--- a/website/openapi_v2.yaml
+++ b/website/openapi_v2.yaml
@@ -11842,9 +11842,8 @@ paths:
             import Facturapi from 'facturapi';
 
             const facturapi = new Facturapi('sk_test_API_KEY');
-            const download = await facturapi.invoices.getDownloadUrl(
-              '58e93bd8e86eb318b019743d',
-              'pdf'
+            const download = await facturapi.invoices.downloadPdfUrl(
+              '58e93bd8e86eb318b019743d'
             );
 
             console.log(download.url, download.expires_at);
@@ -11909,9 +11908,8 @@ paths:
             import Facturapi from 'facturapi';
 
             const facturapi = new Facturapi('sk_test_API_KEY');
-            const download = await facturapi.invoices.getCancellationReceiptDownloadUrl(
-              '58e93bd8e86eb318b019743d',
-              'pdf'
+            const download = await facturapi.invoices.downloadCancellationReceiptPdfUrl(
+              '58e93bd8e86eb318b019743d'
             );
 
             console.log(download.url, download.expires_at);
@@ -11973,7 +11971,7 @@ paths:
             import Facturapi from 'facturapi';
 
             const facturapi = new Facturapi('sk_test_API_KEY');
-            const download = await facturapi.receipts.getDownloadUrl(
+            const download = await facturapi.receipts.downloadPdfUrl(
               '58e93bd8e86eb318b019743d'
             );
 
@@ -12027,9 +12025,8 @@ paths:
             import Facturapi from 'facturapi';
 
             const facturapi = new Facturapi('sk_test_API_KEY');
-            const download = await facturapi.retentions.getDownloadUrl(
-              '58e93bd8e86eb318b019743d',
-              'pdf'
+            const download = await facturapi.retentions.downloadPdfUrl(
+              '58e93bd8e86eb318b019743d'
             );
 
             console.log(download.url, download.expires_at);

--- a/website/openapi_v2.yaml
+++ b/website/openapi_v2.yaml
@@ -11867,6 +11867,10 @@ paths:
           $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthenticated"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/Conflict"
         "429":
           $ref: "#/components/responses/RateLimited"
         "500":
@@ -11917,6 +11921,8 @@ paths:
           $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthenticated"
+        "404":
+          $ref: "#/components/responses/NotFound"
         "429":
           $ref: "#/components/responses/RateLimited"
         "500":
@@ -11958,6 +11964,8 @@ paths:
           $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthenticated"
+        "404":
+          $ref: "#/components/responses/NotFound"
         "429":
           $ref: "#/components/responses/RateLimited"
         "500":
@@ -12009,6 +12017,10 @@ paths:
           $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthenticated"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/Conflict"
         "429":
           $ref: "#/components/responses/RateLimited"
         "500":
@@ -12604,6 +12616,11 @@ components:
     SignedDownloadUrl:
       type: object
       description: Enlace temporal de descarga de un archivo.
+      required:
+        - url
+        - expires_at
+        - content_type
+        - filename
       properties:
         url:
           type: string

--- a/website/openapi_v2.yaml
+++ b/website/openapi_v2.yaml
@@ -4334,6 +4334,43 @@ paths:
           $ref: "#/components/responses/RateLimited"
         "500":
           $ref: "#/components/responses/UnexpectedError"
+  /invoices/preview/pdf/download-url:
+    post:
+      operationId: previewInvoicePdfUrl
+      tags:
+        - invoice
+      summary: Obtener URL del preview PDF de factura
+      description: Devuelve una URL temporal para el preview PDF de una factura sin timbrar.
+      x-codeSamples:
+        - lang: JavaScript
+          label: Node.js
+          source: |
+            const download = await facturapi.invoices.previewPdfUrl({
+              customer: 'cus_123',
+              items: [{ product: 'prod_123' }],
+              payment_form: '06'
+            });
+            console.log(download.url, download.expires_at);
+      requestBody:
+        $ref: "#/components/requestBodies/InvoiceCreate"
+      security:
+        - "SecretLiveKey": []
+        - "SecretTestKey": []
+      responses:
+        "200":
+          description: URL temporal de descarga para el preview PDF.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SignedDownloadUrl"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthenticated"
+        "429":
+          $ref: "#/components/responses/RateLimited"
+        "500":
+          $ref: "#/components/responses/UnexpectedError"
   /invoices/{invoice_id}:
     get:
       operationId: getInvoice
@@ -6550,6 +6587,45 @@ paths:
           $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthenticated"
+        "500":
+          $ref: "#/components/responses/UnexpectedError"
+  /receipts/to-invoice/preview/download-url:
+    post:
+      operationId: previewToInvoiceFromReceiptsUrl
+      tags:
+        - receipt
+      summary: Obtener URL del preview de factura de recibos
+      description: Devuelve una URL temporal para el preview PDF de una factura construida con los recibos seleccionados.
+      x-codeSamples:
+        - lang: JavaScript
+          label: Node.js
+          source: |
+            const download = await facturapi.receipts.previewToInvoicePdfUrl({
+              keys: ['ticket_1001', 'ticket_1002'],
+              customer: 'cus_123',
+              use: 'G03'
+            });
+            console.log(download.url, download.expires_at);
+      requestBody:
+        $ref: "#/components/requestBodies/ReceiptPreviewToInvoice"
+      security:
+        - "SecretLiveKey": []
+        - "SecretTestKey": []
+      responses:
+        "200":
+          description: URL temporal de descarga para el preview PDF.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SignedDownloadUrl"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthenticated"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "429":
+          $ref: "#/components/responses/RateLimited"
         "500":
           $ref: "#/components/responses/UnexpectedError"
   /receipts/global-invoice:

--- a/website/openapi_v2.yaml
+++ b/website/openapi_v2.yaml
@@ -11836,6 +11836,18 @@ paths:
           source: |
             curl https://www.facturapi.io/v2/invoices/58e93bd8e86eb318b019743d/download-url/pdf \
               -H "Authorization: Bearer sk_test_API_KEY"
+        - lang: JavaScript
+          label: Node.js
+          source: |
+            import Facturapi from 'facturapi';
+
+            const facturapi = new Facturapi('sk_test_API_KEY');
+            const download = await facturapi.invoices.getDownloadUrl(
+              '58e93bd8e86eb318b019743d',
+              'pdf'
+            );
+
+            console.log(download.url, download.expires_at);
       parameters:
         - in: path
           name: invoice_id
@@ -11891,6 +11903,18 @@ paths:
           source: |
             curl https://www.facturapi.io/v2/invoices/58e93bd8e86eb318b019743d/cancellation_receipt/download-url/pdf \
               -H "Authorization: Bearer sk_test_API_KEY"
+        - lang: JavaScript
+          label: Node.js
+          source: |
+            import Facturapi from 'facturapi';
+
+            const facturapi = new Facturapi('sk_test_API_KEY');
+            const download = await facturapi.invoices.getCancellationReceiptDownloadUrl(
+              '58e93bd8e86eb318b019743d',
+              'pdf'
+            );
+
+            console.log(download.url, download.expires_at);
       parameters:
         - in: path
           name: invoice_id
@@ -11943,6 +11967,17 @@ paths:
           source: |
             curl https://www.facturapi.io/v2/receipts/58e93bd8e86eb318b019743d/download-url/pdf \
               -H "Authorization: Bearer sk_test_API_KEY"
+        - lang: JavaScript
+          label: Node.js
+          source: |
+            import Facturapi from 'facturapi';
+
+            const facturapi = new Facturapi('sk_test_API_KEY');
+            const download = await facturapi.receipts.getDownloadUrl(
+              '58e93bd8e86eb318b019743d'
+            );
+
+            console.log(download.url, download.expires_at);
       parameters:
         - in: path
           name: receipt_id
@@ -11986,6 +12021,18 @@ paths:
           source: |
             curl https://www.facturapi.io/v2/retentions/58e93bd8e86eb318b019743d/download-url/pdf \
               -H "Authorization: Bearer sk_test_API_KEY"
+        - lang: JavaScript
+          label: Node.js
+          source: |
+            import Facturapi from 'facturapi';
+
+            const facturapi = new Facturapi('sk_test_API_KEY');
+            const download = await facturapi.retentions.getDownloadUrl(
+              '58e93bd8e86eb318b019743d',
+              'pdf'
+            );
+
+            console.log(download.url, download.expires_at);
       parameters:
         - in: path
           name: retention_id

--- a/website/openapi_v2.yaml
+++ b/website/openapi_v2.yaml
@@ -4826,7 +4826,7 @@ paths:
       tags:
         - invoice
       summary: Descargar acuse de cancelación
-      description: Descarga acuse de recibo de cancelación de una factura en un archivo xml o pdf.
+      description: Descarga en XML o PDF el acuse emitido por el SAT al solicitar la cancelación mediante Facturapi. El acuse contiene el resultado inmediato de la solicitud y no necesariamente acredita que el CFDI ya esté cancelado; consulta el estado de la factura para confirmar el desenlace.
       x-codeSamples:
         - lang: Bash
           label: cURL
@@ -12021,7 +12021,7 @@ paths:
         - invoice
       summary: Obtener enlace del acuse de cancelación
       description: |
-        Devuelve un enlace temporal para descargar el acuse de recibo de cancelación de una factura en XML o PDF, sin que el archivo pase por tu servidor.
+        Devuelve un enlace temporal para descargar en XML o PDF el acuse emitido por el SAT al solicitar la cancelación mediante Facturapi. El acuse contiene el resultado inmediato de la solicitud y no necesariamente acredita que el CFDI ya esté cancelado; consulta el estado de la factura para confirmar el desenlace.
 
         El enlace da acceso a ese archivo mientras siga vigente: trátalo como una credencial y no lo almacenes.
       x-codeSamples:

--- a/website/openapi_v2.yaml
+++ b/website/openapi_v2.yaml
@@ -11820,6 +11820,199 @@ paths:
           $ref: "#/components/responses/RateLimited"
         "500":
           $ref: "#/components/responses/UnexpectedError"
+  /invoices/{invoice_id}/download-url/{format}:
+    get:
+      operationId: getInvoiceDownloadUrl
+      tags:
+        - invoice
+      summary: Obtener enlace de descarga
+      description: |
+        Devuelve un enlace temporal para descargar la factura en PDF, XML o ambos en un archivo comprimido ZIP, sin que el archivo pase por tu servidor.
+
+        El enlace da acceso a ese archivo mientras siga vigente: trátalo como una credencial y no lo almacenes.
+      x-codeSamples:
+        - lang: Bash
+          label: cURL
+          source: |
+            curl https://www.facturapi.io/v2/invoices/58e93bd8e86eb318b019743d/download-url/pdf \
+              -H "Authorization: Bearer sk_test_API_KEY"
+      parameters:
+        - in: path
+          name: invoice_id
+          schema:
+            type: string
+          required: true
+          description: ID del objeto a descargar
+        - in: path
+          name: format
+          schema:
+            type: string
+            enum:
+              - pdf
+              - xml
+              - zip
+          required: true
+          description: Formato del archivo de descarga
+      security:
+        - "SecretLiveKey": []
+        - "SecretTestKey": []
+      responses:
+        "200":
+          description: Enlace temporal de descarga del comprobante CFDI en el formato solicitado
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SignedDownloadUrl"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthenticated"
+        "429":
+          $ref: "#/components/responses/RateLimited"
+        "500":
+          $ref: "#/components/responses/UnexpectedError"
+  /invoices/{invoice_id}/cancellation_receipt/download-url/{format}:
+    get:
+      operationId: getCancellationReceiptDownloadUrl
+      tags:
+        - invoice
+      summary: Obtener enlace del acuse de cancelación
+      description: |
+        Devuelve un enlace temporal para descargar el acuse de recibo de cancelación de una factura en XML o PDF, sin que el archivo pase por tu servidor.
+
+        El enlace da acceso a ese archivo mientras siga vigente: trátalo como una credencial y no lo almacenes.
+      x-codeSamples:
+        - lang: Bash
+          label: cURL
+          source: |
+            curl https://www.facturapi.io/v2/invoices/58e93bd8e86eb318b019743d/cancellation_receipt/download-url/pdf \
+              -H "Authorization: Bearer sk_test_API_KEY"
+      parameters:
+        - in: path
+          name: invoice_id
+          schema:
+            type: string
+          required: true
+          description: ID del objeto a descargar
+        - in: path
+          name: format
+          schema:
+            type: string
+            enum:
+              - xml
+              - pdf
+          required: true
+          description: Formato del acuse de cancelación
+      security:
+        - "SecretLiveKey": []
+        - "SecretTestKey": []
+      responses:
+        "200":
+          description: Enlace temporal de descarga del acuse de cancelación en el formato solicitado
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SignedDownloadUrl"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthenticated"
+        "429":
+          $ref: "#/components/responses/RateLimited"
+        "500":
+          $ref: "#/components/responses/UnexpectedError"
+  /receipts/{receipt_id}/download-url/pdf:
+    get:
+      operationId: getReceiptDownloadUrl
+      tags:
+        - receipt
+      summary: Obtener enlace de descarga
+      description: |
+        Devuelve un enlace temporal para descargar el recibo digital en PDF, sin que el archivo pase por tu servidor.
+
+        El enlace da acceso a ese archivo mientras siga vigente: trátalo como una credencial y no lo almacenes.
+      x-codeSamples:
+        - lang: Bash
+          label: cURL
+          source: |
+            curl https://www.facturapi.io/v2/receipts/58e93bd8e86eb318b019743d/download-url/pdf \
+              -H "Authorization: Bearer sk_test_API_KEY"
+      parameters:
+        - in: path
+          name: receipt_id
+          schema:
+            type: string
+          required: true
+          description: ID del objeto a descargar
+      security:
+        - "SecretLiveKey": []
+        - "SecretTestKey": []
+      responses:
+        "200":
+          description: Enlace temporal de descarga del recibo digital en formato PDF
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SignedDownloadUrl"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthenticated"
+        "429":
+          $ref: "#/components/responses/RateLimited"
+        "500":
+          $ref: "#/components/responses/UnexpectedError"
+  /retentions/{retention_id}/download-url/{format}:
+    get:
+      operationId: getRetentionDownloadUrl
+      tags:
+        - retention
+      summary: Obtener enlace de descarga
+      description: |
+        Devuelve un enlace temporal para descargar la retención en PDF, XML o ambos en un archivo comprimido ZIP, sin que el archivo pase por tu servidor.
+
+        El enlace da acceso a ese archivo mientras siga vigente: trátalo como una credencial y no lo almacenes.
+      x-codeSamples:
+        - lang: Bash
+          label: cURL
+          source: |
+            curl https://www.facturapi.io/v2/retentions/58e93bd8e86eb318b019743d/download-url/pdf \
+              -H "Authorization: Bearer sk_test_API_KEY"
+      parameters:
+        - in: path
+          name: retention_id
+          schema:
+            type: string
+          required: true
+          description: ID del objeto a descargar
+        - in: path
+          name: format
+          schema:
+            type: string
+            enum:
+              - pdf
+              - xml
+              - zip
+          required: true
+          description: Formato del archivo de descarga
+      security:
+        - "SecretLiveKey": []
+        - "SecretTestKey": []
+      responses:
+        "200":
+          description: Enlace temporal de descarga de la retención en el formato solicitado
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SignedDownloadUrl"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthenticated"
+        "429":
+          $ref: "#/components/responses/RateLimited"
+        "500":
+          $ref: "#/components/responses/UnexpectedError"
 x-webhooks:
   "Factura global creada":
     post:
@@ -12408,6 +12601,25 @@ components:
       description: Número del 1 al 100 que representa la cantidad máxima de resultados a regresar con motivos de paginación.
 
   schemas:
+    SignedDownloadUrl:
+      type: object
+      description: Enlace temporal de descarga de un archivo.
+      properties:
+        url:
+          type: string
+          description: Enlace de descarga. Da acceso al archivo mientras siga vigente.
+        expires_at:
+          type: string
+          format: date-time
+          description: Momento en el que el enlace deja de funcionar.
+        content_type:
+          type: string
+          description: Tipo de contenido del archivo.
+          example: application/pdf
+        filename:
+          type: string
+          description: Nombre sugerido del archivo.
+          example: invoice.pdf
     SearchKeyDescriptionResult:
       type: object
       properties:

--- a/website/openapi_v2.yaml
+++ b/website/openapi_v2.yaml
@@ -4110,6 +4110,58 @@ paths:
           $ref: "#/components/responses/RateLimited"
         "500":
           $ref: "#/components/responses/UnexpectedError"
+  /invoices/zip-requests/{id}/download-url:
+    get:
+      operationId: getInvoiceZipRequestDownloadUrl
+      tags:
+        - invoice
+      summary: Obtener URL de descarga del ZIP mensual
+      description: |
+        Devuelve una URL temporal para descargar el ZIP de una solicitud terminada sin que el archivo viaje a través de tu servidor.
+
+        La URL permite acceder únicamente a ese archivo mientras sea válida: trátala como una credencial y no la almacenes. Requiere una llave de API de organización en ambiente Live, una suscripción activa y permiso para leer facturas.
+      x-codeSamples:
+        - lang: Bash
+          label: cURL
+          source: |
+            curl https://www.facturapi.io/v2/invoices/zip-requests/66b0f0000000000000000000/download-url \
+              -H "Authorization: Bearer sk_live_API_KEY"
+        - lang: JavaScript
+          label: Node.js
+          source: |
+            import Facturapi from 'facturapi';
+
+            const facturapi = new Facturapi('sk_live_API_KEY');
+            const download = await facturapi.invoices.downloadZipRequestUrl(
+              '66b0f0000000000000000000'
+            );
+
+            console.log(download.url, download.expires_at);
+      parameters:
+        - $ref: "#/components/parameters/InvoiceZipRequestId"
+      security:
+        - "SecretLiveKey": []
+      responses:
+        "200":
+          description: URL temporal de descarga para el archivo ZIP generado.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SignedDownloadUrl"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthenticated"
+        "402":
+          $ref: "#/components/responses/InvoiceZipRequestAccessRequired"
+        "404":
+          $ref: "#/components/responses/InvoiceZipRequestNotFound"
+        "409":
+          $ref: "#/components/responses/InvoiceZipRequestNotReady"
+        "429":
+          $ref: "#/components/responses/RateLimited"
+        "500":
+          $ref: "#/components/responses/UnexpectedError"
   /invoices/preview/pdf:
     post:
       operationId: previewInvoicePdf


### PR DESCRIPTION
Documents the signed download URL endpoints for invoices, cancellation receipts, receipts, and retentions in both Spanish and English, together with the shared `SignedDownloadUrl` response schema.

Each endpoint keeps its available formats explicit. The response schema marks all four returned fields as required, and the endpoint contracts include their applicable 404 and 409 responses. Node.js examples show the corresponding SDK method for every resource without exposing storage implementation details.

Core implementation: FacturAPI/facturapi#2285. Node SDK: FacturAPI/facturapi-node#118.

Validation: both OpenAPI YAML documents parse successfully.